### PR TITLE
Create indices according to specs

### DIFF
--- a/etc/sphinxsearch/sphinx.conf
+++ b/etc/sphinxsearch/sphinx.conf
@@ -228,6 +228,8 @@ source src_ch_astra_ivs-nat : def_pqsql
             , remove_accents(ivs_slaname)||' '||remove_accents(ivs_nummer)||' '||remove_accents(ivs_signatur) as detail \
             , 'ch.astra.ivs-nat' as layer \
             , quadindex(the_geom) as geom_quadindex \
+            , y(st_transform(st_centroid(the_geom),4326)) as lat \
+            , x(st_transform(st_centroid(the_geom),4326)) as lon \
             , st_box2d(the_geom) as geom_st_box2d   \
             , nat_id::bigint as id \
         from astra.ivs_nat
@@ -236,6 +238,8 @@ source src_ch_astra_ivs-nat : def_pqsql
     sql_attr_string = layer
     sql_attr_string = geom_st_box2d
     sql_attr_string = label
+    sql_attr_float = lat
+    sql_attr_float = lon
     sql_field_string = geom_quadindex
     sql_field_string = detail 
 }
@@ -250,6 +254,8 @@ source src_ch_astra_ivs-reg_loc : def_pqsql
             , remove_accents(ivs_slaname)||' '||remove_accents(ivs_nummer)||' '||remove_accents(ivs_signatur) as detail \
             , 'ch.astra.ivs-reg_loc' as layer \
             , quadindex(the_geom) as geom_quadindex \
+            , y(st_transform(st_centroid(the_geom),4326)) as lat \
+            , x(st_transform(st_centroid(the_geom),4326)) as lon \
             , st_box2d(the_geom) as geom_st_box2d \
             , reg_loc_id::bigint as id \
         from astra.ivs_reg_loc
@@ -258,6 +264,8 @@ source src_ch_astra_ivs-reg_loc : def_pqsql
     sql_attr_string = layer
     sql_attr_string = label
     sql_attr_string = geom_st_box2d
+    sql_attr_float = lat
+    sql_attr_float = lon
     sql_field_string = geom_quadindex
     sql_field_string = detail
 }
@@ -273,6 +281,8 @@ source src_ch_bfs_gebaeude_wohnungs_register : def_pqsql
         , origin as origin \
         , 'ch.bfs.gebaeude_wohnungs_register' as layer \
         , quadindex(the_geom) as geom_quadindex \
+        , y(st_transform(st_centroid(the_geom),4326)) as lat \
+        , x(st_transform(st_centroid(the_geom),4326)) as lon \
         , st_box2d(the_geom) as geom_st_box2d \
         , rank as rank \
         , gid as id \
@@ -284,6 +294,8 @@ source src_ch_bfs_gebaeude_wohnungs_register : def_pqsql
     sql_attr_string = label
     sql_attr_string = origin
     sql_attr_string = geom_st_box2d
+    sql_attr_float = lat
+    sql_attr_float = lon
     sql_field_string = geom_quadindex
 }
 

--- a/lib/sphinxapi/test.py
+++ b/lib/sphinxapi/test.py
@@ -8,18 +8,19 @@ import sys, time
 if not sys.argv[1:]:
         print "Usage: python test.py [OPTIONS] query words\n"
         print "Options are:"
-        print "-h, --host <HOST>\tconnect to searchd at host HOST"
-        print "-p, --port\t\tconnect to searchd at port PORT"
-        print "-i, --index <IDX>\tsearch through index(es) specified by IDX"
-        print "-s, --sortby <EXPR>\tsort matches by 'EXPR'"
-        print "-a, --any\t\tuse 'match any word' matching mode"
-        print "-b, --boolean\t\tuse 'boolean query' matching mode"
-        print "-e, --extended\t\tuse 'extended query' matching mode"
-        print "-f, --filter <ATTR>\tfilter by attribute 'ATTR' (default is 'group_id')"
-        print "-v, --value <VAL>\tadd VAL to allowed 'group_id' values list"
-        print "-g, --groupby <EXPR>\tgroup matches by 'EXPR'"
-        print "-gs,--groupsort <EXPR>\tsort groups by 'EXPR'"
-        print "-l, --limit <COUNT>\tretrieve COUNT matches (default is 20)"
+        print "-h, --host <HOST>\t\tconnect to searchd at host HOST"
+        print "-p, --port\t\t\tconnect to searchd at port PORT"
+        print "-i, --index <IDX>\t\tsearch through index(es) specified by IDX"
+        print "-s, --sortby <EXPR>\t\tsort matches by 'EXPR'"
+        print "-a, --any\t\t\tuse 'match any word' matching mode"
+        print "-b, --boolean\t\t\tuse 'boolean query' matching mode"
+        print "-e, --extended\t\t\tuse 'extended query' matching mode"
+        print "-f, --filter <ATTR>\t\tfilter by attribute 'ATTR' (default is 'group_id')"
+        print "-v, --value <VAL>\t\tadd VAL to allowed 'group_id' values list"
+        print "-g, --groupby <EXPR>\t\tgroup matches by 'EXPR'"
+        print "-gs,--groupsort <EXPR>\t\tsort groups by 'EXPR'"
+        print "-l, --limit <COUNT>\t\tretrieve COUNT matches (default is 20)"
+        print "-ga, --geoanchor <LAT> <LON>\tsets GeoAnchor at given lat/lon (in minutes decimal). Index must contain lat/lon attributes"
         sys.exit(0)
 
 q = ''
@@ -33,6 +34,7 @@ sortby = ''
 groupby = ''
 groupsort = '@group desc'
 limit = 0
+geoanchor = []
 
 i = 1
 while (i<len(sys.argv)):
@@ -70,6 +72,11 @@ while (i<len(sys.argv)):
         elif arg=='-l' or arg=='--limit':
                 i += 1
                 limit = int(sys.argv[i])
+        elif arg=='-ga' or arg=='--geoanchor':
+                i += 1
+                geoanchor.append(float(sys.argv[i]))
+                i += 1
+                geoanchor.append(float(sys.argv[i]))
         else:
                 q = '%s%s ' % ( q, arg )
         i += 1
@@ -78,6 +85,8 @@ while (i<len(sys.argv)):
 cl = SphinxClient()
 cl.SetServer ( host, port )
 cl.SetMatchMode ( mode )
+if len(geoanchor) > 1:
+        cl.SetGeoAnchor('lat', 'lon', geoanchor[0], geoanchor[1])
 if filtervals:
         cl.SetFilter ( filtercol, filtervals )
 if groupby:


### PR DESCRIPTION
This PR creates indices [according to the specs defined in the wiki](https://github.com/geoadmin/service-sphinxsearch/wiki/Search-Requirements)
- Remove all unnecessary stuff
  -- Remove quadindex where it's not needed (swisssearch)
  -- Remove detail where it's not needed (feature search for queryable layers)
- Use prefix for quadindex instead of infix (feature search for both queryable and searchable layers)
- Use infix of length 2 for all searches with detail search
- Make sure that all feature searches contain the same attributes
- Add lon/lat attributes in feature indices. This allows [`SetGeoAnchor`](http://sphinxsearch.com/docs/manual-2.0.9.html#api-func-setgeoanchor) filtering and sorting
- Some refactoring to have clearer code
- Adapted test script to allow testing of geoanchor (see below for test command)

These changes result in [smaller indices and faster index creationg](https://github.com/geoadmin/service-sphinxsearch/wiki/Infix,-Prefix,-Star-Search)

Note that the current indices on the dev machine are created with this.

Testing command for GeoAnchor:

`python test.py -i ch_astra_ivs-reg_loc -e "@geom_quadindex 0*" -ga 46.95109 7.43863 -s "@geodist ASC"`

This will return all features on the index (geom_quadindex 0\* returns all features) but sorted by distance to the reference (which is 600000/200000). Note that geoAnchor works with lat/lon only.
