### PR TITLE
Address index for geocoding

### DIFF
--- a/conf/sphinx.conf.in
+++ b/conf/sphinx.conf.in
@@ -36,28 +36,27 @@ source src_address : src_swisssearch
         where origin = 'address'
 }
 
-source src_address_geocoding : src_address
-{
-    sql_attr_float = lat
-    sql_attr_float = lon
-    sql_field_string = geom_quadindex
-    sql_query = \
-        SELECT \
-        gid as id \
-        , search_name as detail \
-        , coalesce(strname1,'')||' '||coalesce(deinr,'')||' <b>'||coalesce(plz,'')||' '||coalesce(ort_27,'')||'</b>' as label \
-        , origin as origin \
-        , quadindex(the_geom) as geom_quadindex \
-        , y(st_transform(st_centroid(the_geom),4326)) as lat \
-        , x(st_transform(st_centroid(the_geom),4326)) as lon \
-        , st_box2d(the_geom) as geom_st_box2d \
-        , rank as rank \
-        , gid as id \
-        , NULLIF(regexp_replace(deinr::text, '[^0-9]'::text, ''::text, 'g'::text), ''::text)::integer as num \
-        from swiss_search \
-        where origin = 'address'
-}
-
+#source src_address_geocoding : src_address
+#{
+#    sql_attr_float = lat
+#    sql_attr_float = lon
+#    sql_field_string = geom_quadindex
+#    sql_query = \
+#        SELECT \
+#        gid as id \
+#        , search_name as detail \
+#        , coalesce(strname1,'')||' '||coalesce(deinr,'')||' <b>'||coalesce(plz,'')||' '||coalesce(ort_27,'')||'</b>' as label \
+#        , origin as origin \
+#        , quadindex(the_geom) as geom_quadindex \
+#        , y(st_transform(st_centroid(the_geom),4326)) as lat \
+#        , x(st_transform(st_centroid(the_geom),4326)) as lon \
+#        , st_box2d(the_geom) as geom_st_box2d \
+#        , rank as rank \
+#        , gid as id \
+#        , NULLIF(regexp_replace(deinr::text, '[^0-9]'::text, ''::text, 'g'::text), ''::text)::integer as num \
+#        from swiss_search \
+#        where origin = 'address'
+#}
 
 source src_parcel : src_swisssearch
 {
@@ -830,12 +829,12 @@ index address : zipcode
     path = /var/lib/sphinxsearch/data/index/address
 }
 
-index address_geocoding : zipcode
-{
-    source = src_address_geocoding
-    path = /var/lib/sphinxsearch/data/index/address_geocoding
-
-}
+# only create on demand
+#index address_geocoding : zipcode
+#{
+#    source = src_address_geocoding
+#    path = /var/lib/sphinxsearch/data/index/address_geocoding
+#}
 
 # Not needed currently
 #index address_fuzzy : zipcode


### PR DESCRIPTION
This PR adds a new index that will allow the geocoding (and reverse) of addresses. It's a new index to not conflict with the existing address index (which is used in a distributed index).

As of now, it is uncommented, because this index will be created on demand only. You have to uncomment the source and index section to create it.
