### PR TITLE
LFP2 index fix

### DIFF
--- a/conf/sphinx.conf.in
+++ b/conf/sphinx.conf.in
@@ -909,7 +909,7 @@ index ch_swisstopo_fixpunkte-lfp1 : ch_astra_ivs-nat
 index ch_swisstopo_fixpunkte-lfp2 : ch_astra_ivs-nat
 {
     source =  src_ch_swisstopo_fixpunkte-lfp2
-    path = /var/lib/sphinxsearch/data/index/ch_swisstopo_fixpunkte-lfp1
+    path = /var/lib/sphinxsearch/data/index/ch_swisstopo_fixpunkte-lfp2
 }
 
 index ch_swisstopo_fixpunkte-hfp1 : ch_astra_ivs-nat


### PR DESCRIPTION
lfp1 index contained the lfp2 data and there was not lfp2 index created with the current configuration. This PR addresses this error.

Indices are re-created on test. Currently, deployment to integration is underway.
