### PR TITLE
Add possibility to create single index

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
 IPATTERN ?= 'Set IPATTERN variable in call'
+INDEX ?= 'Set INDEX variable to specify the index to create'
 FEATURES_INDICES := $(shell find /var/lib/sphinxsearch/data/index/ -type f -name 'ch_*spa' | sed 's:/var/lib/sphinxsearch/data/index/::' |  sed 's:.spa::')
 GREP_INDICES := $(shell grep "^index .*$(IPATTERN).* : " conf/sphinx.conf | sed 's:index ::' | sed 's: \: .*::')
 
@@ -22,6 +23,10 @@ help:
 	@echo "Deploy:"
 	@echo "- deploy-ab	Deploy all the indices in integration"
 	@echo "- deploy-prod	Deploy all the indices in production"
+
+.PHONY: index
+index: move-template
+	indexer --verbose --rotate --config conf/sphinx.conf  --sighup-each $(INDEX)
 
 .PHONY: index-all
 index-all: move-template


### PR DESCRIPTION
This PR allows to create a single specific index. Note that `index-grep` allows this already. There are uses cases where `index-grep` does not work though. For instance, when I want to create `ch_bfs_arealstatistik-bodenbedeckung` then

`make index-grep IPATTERN=ch_bfs_arealstatistik-bodenbedeckung`

will create
`ch_bfs_arealstatistik-bodenbedeckung`, `ch_bfs_arealstatistik-bodenbedeckung-1985` and `ch_bfs_arealstatistik-bodenbedeckung-1997`, which is not what I want.

The new
`make index INDEX=ch_bfs_arealstatistik-bodenbedeckung`
will allow this use case.
