### PR TITLE
Fix make index-grep

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 IPATTERN ?= 'Set IPATTERN variable in call'
 INDEX ?= 'Set INDEX variable to specify the index to create'
 FEATURES_INDICES := $(shell find /var/lib/sphinxsearch/data/index/ -type f -name 'ch_*spa' | sed 's:/var/lib/sphinxsearch/data/index/::' |  sed 's:.spa::')
-GREP_INDICES := $(shell if [ -f conf/sphinx.conf ]; then grep "^index .*$(IPATTERN).* : " conf/sphinx.conf | sed 's:index ::' | sed 's: \: .*::'; fi)
+GREP_INDICES := $(shell if [ -f conf/sphinx.conf ]; then grep "^index .*$(IPATTERN).*" conf/sphinx.conf | sed 's: \: .*::' | grep ".*$(IPATTERN).*" | sed 's:index ::'; fi)
 
 .PHONY: help
 help:


### PR DESCRIPTION
`make index-grep IPATTERN=mypattern` did not work when
a) an index would match the pattern but did not have a parent index definition (missed the colong in the definition)
b) the pattern was the parent of an index (all indices where the pattern was the parent would be re-created)

This PR addresses this and make sure that only indices matching the pattern are created.
