### PR TITLE
replace non existing bgdi_id column with on the fly conter column

### DIFF
--- a/conf/are.conf.part
+++ b/conf/are.conf.part
@@ -6,7 +6,7 @@ source src_ch_are_landschaftstypen : def_queryable_features
 {
     sql_db = are
     sql_query = \
-        SELECT bgdi_id as id \
+       SELECT row_number() OVER(ORDER BY row_id asc) as id \
             , 'feature' as origin \
             , 'ch.are.landschaftstypen' as layer \
             , quadindex(the_geom) as geom_quadindex \


### PR DESCRIPTION
bgdi_id column does not exist in the database.
This pull request is replacing the bgdi_id column in the index source with an on the fly counter.
