### PR TITLE
Set the number of dist_threads to 7

### DIFF
--- a/conf/db.conf.in
+++ b/conf/db.conf.in
@@ -56,7 +56,7 @@ searchd
     listen = localhost:9306:mysql41
     ondisk_dict_default = 1
     preopen_indexes = 0
-    dist_threads = 4
+    dist_threads = 7
     read_timeout = 5
     max_children = 50
     max_matches = 10000


### PR DESCRIPTION
http://notes.jschutz.net/2011/03/sphinx-search-engine-comparative-benchmarks/

I found an interesting article ("see above") about Sphinx performance.

It seems that the best performance is achieved when 

dist_threads = number of indices

So I tried to change that to 7 (7 different search indices) and found out the performance really improved.

I was able to perform 492 random requests on test in 
66 seconds
while it was taking around
76 seconds
before that change.

I think it is a good improvement. (You can find the script on mf1t in my sandbox)
