### PR TITLE
use pregenerated quadindex

### DIFF
--- a/conf/search.conf.part
+++ b/conf/search.conf.part
@@ -23,7 +23,7 @@ source src_address : src_swisssearch
         , detail \
         , label \
         , origin \
-        , quadindex(the_geom) as geom_quadindex \
+        , bgdi_quadindex as geom_quadindex \
         , geom_st_box2d \
         , 6::integer as rank \
         , x \
@@ -41,7 +41,7 @@ source src_parcel : src_swisssearch
         , detail \
         , label \
         , origin \
-        , quadindex(the_geom) as geom_quadindex \
+        , bgdi_quadindex as geom_quadindex \
         , geom_st_box2d \
         , 10::integer as rank \
         , x \


### PR DESCRIPTION
the pregenerated quadindex columns for the parcel and adress have been established on pg_dev, pg_int and pg_prod
we can switch to these columns now for the index update.
see https://github.com/geoadmin/service-sphinxsearch/pull/131
