### PR TITLE
layer index only if bodsearch = true

### DIFF
--- a/conf/bod.conf.part
+++ b/conf/bod.conf.part
@@ -27,7 +27,7 @@ source src_layers_de : layers
             , staging as staging \
             , bgdi_id::bigint as id \
         from \
-            re3.view_bod_layer_info_de 
+            re3.view_bod_layer_info_de where bodsearch = true
 }
 
 source src_layers_fr : layers
@@ -44,7 +44,7 @@ source src_layers_fr : layers
             , staging as staging \
             , bgdi_id::bigint as id \
         from \
-            re3.view_bod_layer_info_fr 
+            re3.view_bod_layer_info_fr where bodsearch = true
 }
 
 source src_layers_en : layers
@@ -61,7 +61,7 @@ source src_layers_en : layers
             , staging as staging \
             , bgdi_id::bigint as id \
         from \
-            re3.view_bod_layer_info_en 
+            re3.view_bod_layer_info_en where bodsearch = true
 }
 
 source src_layers_it : layers
@@ -78,7 +78,7 @@ source src_layers_it : layers
             , staging as staging \
             , bgdi_id::bigint as id \
         from \
-            re3.view_bod_layer_info_it 
+            re3.view_bod_layer_info_it where bodsearch = true
 }
 
 source src_layers_rm : layers
@@ -95,7 +95,7 @@ source src_layers_rm : layers
             , staging as staging \
             , bgdi_id::bigint as id \
         from \
-            re3.view_bod_layer_info_rm 
+            re3.view_bod_layer_info_rm where bodsearch = true
 }
 
 ## INDICES


### PR DESCRIPTION
the attribute bodsearch should be used for the layer index in sphinx
only layers with bodsearch=true should be indexed.
