### PR TITLE
add inherited source template to supporting translated labels

### DIFF
--- a/conf/db.conf.in
+++ b/conf/db.conf.in
@@ -20,10 +20,6 @@ source def_searchable_features : def_pqsql
     sql_attr_float = lat
     sql_attr_float = lon
     sql_field_string = geom_quadindex
-    sql_attr_string = label_de
-    sql_attr_string = label_fr
-    sql_attr_string = label_it
-    sql_attr_string = label_en
     sql_field_string = detail
 }
 


### PR DESCRIPTION
As discussed in 4220590e87402f5f0d6030f0c870ef0c8b9c00fe
this will simplify the config for multilanguage support and get rid of warnings when generating indices