### PR TITLE
Change label and exclude routentyp who are not draw on the map

### DIFF
--- a/conf/uvek.conf.part
+++ b/conf/uvek.conf.part
@@ -108,9 +108,9 @@ source src_ch_astra_ausnahmetransportrouten : def_queryable_features
             , y(st_transform(st_centroid(the_geom),4326)) as lat \
             , x(st_transform(st_centroid(the_geom),4326)) as lon \
             , st_box2d(the_geom) as geom_st_box2d \
-            , ri_getrenn::text as label \
+            , id::text as label \
             , id::text as feature_id \
-        FROM astra.ausnahmetransportrouten
+        FROM astra.ausnahmetransportrouten WHERE (routentyp_id <> 0 AND routentyp_id <> 10)
 }
 
 source src_ch_bfe_abgeltung-wasserkraftnutzung : def_queryable_features


### PR DESCRIPTION
1) Change the label because it's unsuitable (empty or with sign "=" or "?")

2) Remove in sphinx result object with routentyp = 0 or 10 beacause there is no symbology (not visible on the map)
ex : make a select by rectangle arround the point. On test you find only one result (good), and on prod you get lot of object invisible.
url test : http://mf-geoadmin3.dev.bgdi.ch/ltalp/src/?Y=754152.82&X=172695.93&zoom=4&bgLayer=voidLayer&lang=en&topic=ech&layers_timestamp=&layers=ch.astra.ausnahmetransportrouten
url prod : http://map.geo.admin.ch/?Y=754152.82&X=172695.93&zoom=4&bgLayer=voidLayer&lang=en&topic=ech&layers_timestamp=&layers=ch.astra.ausnahmetransportrouten
