### PR TITLE
replace deprecated postgis functions x->st_x y->st_y st_box2->box2d

### DIFF
--- a/conf/are.conf.part
+++ b/conf/are.conf.part
@@ -10,9 +10,9 @@ source src_ch_are_landschaftstypen : def_queryable_features
             , 'feature' as origin \
             , 'ch.are.landschaftstypen' as layer \
             , quadindex(the_geom) as geom_quadindex \
-            , y(st_transform(st_centroid(the_geom),4326)) as lat \
-            , x(st_transform(st_centroid(the_geom),4326)) as lon \
-            , st_box2d(the_geom) as geom_st_box2d \
+            , st_y(st_transform(st_centroid(the_geom),4326)) as lat \
+            , st_x(st_transform(st_centroid(the_geom),4326)) as lon \
+            , box2d(the_geom) as geom_st_box2d \
             , typ_nr::text as label \
             , row_id::text as feature_id \
         FROM siedlung_landschaft.landschaftstypen
@@ -26,9 +26,9 @@ source src_ch_are_alpenkonvention : def_queryable_features
             , 'feature' as origin \
             , 'ch.are.alpenkonvention' as layer \
             , quadindex(the_geom) as geom_quadindex \
-            , y(st_transform(st_centroid(the_geom),4326)) as lat \
-            , x(st_transform(st_centroid(the_geom),4326)) as lon \
-            , st_box2d(the_geom) as geom_st_box2d \
+            , st_y(st_transform(st_centroid(the_geom),4326)) as lat \
+            , st_x(st_transform(st_centroid(the_geom),4326)) as lon \
+            , box2d(the_geom) as geom_st_box2d \
             , stand::text as label \
             , row_id::text as feature_id \
         FROM siedlung_landschaft.alpenkonvention
@@ -42,9 +42,9 @@ source src_ch_are_agglomerationen_isolierte_staedte : def_queryable_features
             , 'feature' as origin \
             , 'ch.are.agglomerationen_isolierte_staedte' as layer \
             , quadindex(the_geom) as geom_quadindex \
-            , y(st_transform(st_centroid(the_geom),4326)) as lat \
-            , x(st_transform(st_centroid(the_geom),4326)) as lon \
-            , st_box2d(the_geom) as geom_st_box2d \
+            , st_y(st_transform(st_centroid(the_geom),4326)) as lat \
+            , st_x(st_transform(st_centroid(the_geom),4326)) as lon \
+            , box2d(the_geom) as geom_st_box2d \
             , name::text as label \
             , row_id::text as feature_id \
         FROM siedlung_landschaft.agglomerationen_isolierte_staedte
@@ -58,9 +58,9 @@ source src_ch_are_gueteklassen_oev : def_queryable_features
             , 'feature' as origin \
             , 'ch.are.gueteklassen_oev' as layer \
             , quadindex(the_geom) as geom_quadindex \
-            , y(st_transform(st_centroid(the_geom),4326)) as lat \
-            , x(st_transform(st_centroid(the_geom),4326)) as lon \
-            , st_box2d(the_geom) as geom_st_box2d \
+            , st_y(st_transform(st_centroid(the_geom),4326)) as lat \
+            , st_x(st_transform(st_centroid(the_geom),4326)) as lon \
+            , box2d(the_geom) as geom_st_box2d \
             , klasse_fr::text as label \
             , id::text as feature_id \
         FROM oeffentlicher_verkehr.gueteklassen
@@ -74,9 +74,9 @@ source src_ch_are_bevoelkerungsdichte : def_queryable_features
             , 'feature' as origin \
             , 'ch.are.bevoelkerungsdichte' as layer \
             , quadindex(the_geom) as geom_quadindex \
-            , y(st_transform(st_centroid(the_geom),4326)) as lat \
-            , x(st_transform(st_centroid(the_geom),4326)) as lon \
-            , st_box2d(the_geom) as geom_st_box2d \
+            , st_y(st_transform(st_centroid(the_geom),4326)) as lat \
+            , st_x(st_transform(st_centroid(the_geom),4326)) as lon \
+            , box2d(the_geom) as geom_st_box2d \
             , popt_ha::text || '[ha]' as label \
             , row_id::text as feature_id \
         FROM siedlung_landschaft.bevoelkerungsdichte
@@ -90,9 +90,9 @@ source src_ch_are_bauzonen : def_queryable_features
             , 'feature' as origin \
             , 'ch.are.bauzonen' as layer \
             , quadindex(the_geom) as geom_quadindex \
-            , y(st_transform(st_centroid(the_geom),4326)) as lat \
-            , x(st_transform(st_centroid(the_geom),4326)) as lon \
-            , st_box2d(the_geom) as geom_st_box2d \
+            , st_y(st_transform(st_centroid(the_geom),4326)) as lat \
+            , st_x(st_transform(st_centroid(the_geom),4326)) as lon \
+            , box2d(the_geom) as geom_st_box2d \
             , name_::text as label \
             , bgdi_id::text as feature_id \
         FROM siedlung_landschaft.bauzonen_2012
@@ -106,9 +106,9 @@ source src_ch_are_gemeindetyp-1990-9klassen : def_queryable_features
             , 'feature' as origin \
             , 'ch.are.gemeindetyp-1990-9klassen' as layer \
             , quadindex(the_geom) as geom_quadindex \
-            , y(st_transform(st_centroid(the_geom),4326)) as lat \
-            , x(st_transform(st_centroid(the_geom),4326)) as lon \
-            , st_box2d(the_geom) as geom_st_box2d \
+            , st_y(st_transform(st_centroid(the_geom),4326)) as lat \
+            , st_x(st_transform(st_centroid(the_geom),4326)) as lon \
+            , box2d(the_geom) as geom_st_box2d \
             , name::text as label \
             , gde_no::text as feature_id \
         FROM siedlung_landschaft.gemeindetyp_1990_9klassen
@@ -122,9 +122,9 @@ source src_ch_are_gemeindetypen : def_queryable_features
             , 'feature' as origin \
             , 'ch.are.gemeindetypen' as layer \
             , quadindex(the_geom) as geom_quadindex \
-            , y(st_transform(st_centroid(the_geom),4326)) as lat \
-            , x(st_transform(st_centroid(the_geom),4326)) as lon \
-            , st_box2d(the_geom) as geom_st_box2d \
+            , st_y(st_transform(st_centroid(the_geom),4326)) as lat \
+            , st_x(st_transform(st_centroid(the_geom),4326)) as lon \
+            , box2d(the_geom) as geom_st_box2d \
             , name_::text as label \
             , bgdi_id::text as feature_id \
         FROM siedlung_landschaft.gemeindetypologie_2012
@@ -138,9 +138,9 @@ source src_ch_are_beschaeftigtendichte : def_queryable_features
             , 'feature' as origin \
             , 'ch.are.beschaeftigtendichte' as layer \
             , quadindex(the_geom) as geom_quadindex \
-            , y(st_transform(st_centroid(the_geom),4326)) as lat \
-            , x(st_transform(st_centroid(the_geom),4326)) as lon \
-            , st_box2d(the_geom) as geom_st_box2d \
+            , st_y(st_transform(st_centroid(the_geom),4326)) as lat \
+            , st_x(st_transform(st_centroid(the_geom),4326)) as lon \
+            , box2d(the_geom) as geom_st_box2d \
             , empt_ha::text || '[ha]' as label \
             , row_id::text as feature_id \
         FROM siedlung_landschaft.beschaeftigtendichte

--- a/conf/bafu.conf.part
+++ b/conf/bafu.conf.part
@@ -11,9 +11,9 @@ source src_ch_bafu_grundwasserschutzareale : def_queryable_features
             , 'feature' as origin \
             , 'ch.bafu.grundwasserschutzareale' as layer \
             , quadindex(the_geom) as geom_quadindex \
-            , y(st_transform(st_centroid(the_geom),4326)) as lat \
-            , x(st_transform(st_centroid(the_geom),4326)) as lon \
-            , st_box2d(the_geom) as geom_st_box2d \
+            , st_y(st_transform(st_centroid(the_geom),4326)) as lat \
+            , st_x(st_transform(st_centroid(the_geom),4326)) as lon \
+            , box2d(the_geom) as geom_st_box2d \
             , typ_de::text as label \
             , typ_de::text as label_de \
             , typ_fr::text as label_fr \
@@ -31,9 +31,9 @@ source src_ch_bafu_grundwasserschutzzonen : def_queryable_features
             , 'feature' as origin \
             , 'ch.bafu.grundwasserschutzzonen' as layer \
             , quadindex(the_geom) as geom_quadindex \
-            , y(st_transform(st_centroid(the_geom),4326)) as lat \
-            , x(st_transform(st_centroid(the_geom),4326)) as lon \
-            , st_box2d(the_geom) as geom_st_box2d \
+            , st_y(st_transform(st_centroid(the_geom),4326)) as lat \
+            , st_x(st_transform(st_centroid(the_geom),4326)) as lon \
+            , box2d(the_geom) as geom_st_box2d \
             , typ_de::text as label \
             , typ_de::text as label_de \
             , typ_fr::text as label_fr \
@@ -51,9 +51,9 @@ source src_ch_bafu_gewaesserschutzbereiche : def_queryable_features
             , 'feature' as origin \
             , 'ch.bafu.gewaesserschutzbereiche' as layer \
             , quadindex(the_geom) as geom_quadindex \
-            , y(st_transform(st_centroid(the_geom),4326)) as lat \
-            , x(st_transform(st_centroid(the_geom),4326)) as lon \
-            , st_box2d(the_geom) as geom_st_box2d \
+            , st_y(st_transform(st_centroid(the_geom),4326)) as lat \
+            , st_x(st_transform(st_centroid(the_geom),4326)) as lon \
+            , box2d(the_geom) as geom_st_box2d \
             , typ_de::text as label \
             , typ_de::text as label_de \
             , typ_fr::text as label_fr \
@@ -71,9 +71,9 @@ source src_ch_bafu_bundesinventare-amphibien_wanderobjekte_anhoerung : def_query
             , 'feature' as origin \
             , 'ch.bafu.bundesinventare-amphibien_wanderobjekte_anhoerung' as layer \
             , quadindex(the_geom) as geom_quadindex \
-            , y(st_transform(st_centroid(the_geom),4326)) as lat \
-            , x(st_transform(st_centroid(the_geom),4326)) as lon \
-            , st_box2d(the_geom) as geom_st_box2d \
+            , st_y(st_transform(st_centroid(the_geom),4326)) as lat \
+            , st_x(st_transform(st_centroid(the_geom),4326)) as lon \
+            , box2d(the_geom) as geom_st_box2d \
             , obj_name::text as label \
             , bgdi_id::text as feature_id \
         FROM bundinv.amphibien_wanderobjekte_anhoerung
@@ -87,9 +87,9 @@ source src_ch_bafu_bundesinventare-amphibien_wanderobjekte : def_queryable_featu
             , 'feature' as origin \
             , 'ch.bafu.bundesinventare-amphibien_wanderobjekte' as layer \
             , quadindex(the_geom) as geom_quadindex \
-            , y(st_transform(st_centroid(the_geom),4326)) as lat \
-            , x(st_transform(st_centroid(the_geom),4326)) as lon \
-            , st_box2d(the_geom) as geom_st_box2d \
+            , st_y(st_transform(st_centroid(the_geom),4326)) as lat \
+            , st_x(st_transform(st_centroid(the_geom),4326)) as lon \
+            , box2d(the_geom) as geom_st_box2d \
             , am_g_name::text as label \
             , am_g_obj::text as feature_id \
         FROM bundinv.am_g
@@ -103,9 +103,9 @@ source src_ch_bafu_bundesinventare-amphibien : def_queryable_features
             , 'feature' as origin \
             , 'ch.bafu.bundesinventare-amphibien' as layer \
             , quadindex(the_geom) as geom_quadindex \
-            , y(st_transform(st_centroid(the_geom),4326)) as lat \
-            , x(st_transform(st_centroid(the_geom),4326)) as lon \
-            , st_box2d(the_geom) as geom_st_box2d \
+            , st_y(st_transform(st_centroid(the_geom),4326)) as lat \
+            , st_x(st_transform(st_centroid(the_geom),4326)) as lon \
+            , box2d(the_geom) as geom_st_box2d \
             , am_l_name::text as label \
             , am_l_obj as feature_id \
         FROM bundinv.am_l
@@ -119,9 +119,9 @@ source src_ch_bafu_bundesinventare-amphibien_anhoerung : def_queryable_features
             , 'feature' as origin \
             , 'ch.bafu.bundesinventare-amphibien_anhoerung' as layer \
             , quadindex(the_geom) as geom_quadindex \
-            , y(st_transform(st_centroid(the_geom),4326)) as lat \
-            , x(st_transform(st_centroid(the_geom),4326)) as lon \
-            , st_box2d(the_geom) as geom_st_box2d \
+            , st_y(st_transform(st_centroid(the_geom),4326)) as lat \
+            , st_x(st_transform(st_centroid(the_geom),4326)) as lon \
+            , box2d(the_geom) as geom_st_box2d \
             , obj_name::text as label \
             , bgdi_id as feature_id \
         FROM bundinv.amphibien_anhoerung
@@ -135,9 +135,9 @@ source src_ch_bafu_bundesinventare-auen_anhoerung : def_queryable_features
             , 'feature' as origin \
             , 'ch.bafu.bundesinventare-auen_anhoerung' as layer \
             , quadindex(the_geom) as geom_quadindex \
-            , y(st_transform(st_centroid(the_geom),4326)) as lat \
-            , x(st_transform(st_centroid(the_geom),4326)) as lon \
-            , st_box2d(the_geom) as geom_st_box2d \
+            , st_y(st_transform(st_centroid(the_geom),4326)) as lat \
+            , st_x(st_transform(st_centroid(the_geom),4326)) as lon \
+            , box2d(the_geom) as geom_st_box2d \
             , obj_name::text as label \
             , bgdi_id as feature_id \
         FROM bundinv.auen_anhoerung
@@ -151,9 +151,9 @@ source src_ch_bafu_hydrologie-hydromessstationen : def_queryable_features
             , 'feature' as origin \
             , 'ch.bafu.hydrologie-hydromessstationen' as layer \
             , quadindex(the_geom) as geom_quadindex \
-            , y(st_transform(st_centroid(the_geom),4326)) as lat \
-            , x(st_transform(st_centroid(the_geom),4326)) as lon \
-            , st_box2d(the_geom) as geom_st_box2d \
+            , st_y(st_transform(st_centroid(the_geom),4326)) as lat \
+            , st_x(st_transform(st_centroid(the_geom),4326)) as lon \
+            , box2d(the_geom) as geom_st_box2d \
             , lhg_name::text as label \
             , edv_nr4::text as feature_id \
         FROM hydrologie.lhg
@@ -167,9 +167,9 @@ source src_ch_bafu_wasser-teileinzugsgebiete_2 : def_queryable_features
             , 'feature' as origin \
             , 'ch.bafu.wasser-teileinzugsgebiete_2' as layer \
             , quadindex(the_geom) as geom_quadindex \
-            , y(st_transform(st_centroid(the_geom),4326)) as lat \
-            , x(st_transform(st_centroid(the_geom),4326)) as lon \
-            , st_box2d(the_geom) as geom_st_box2d \
+            , st_y(st_transform(st_centroid(the_geom),4326)) as lat \
+            , st_x(st_transform(st_centroid(the_geom),4326)) as lon \
+            , box2d(the_geom) as geom_st_box2d \
             , teilezgnr::text as label \
             , bgdi_id::text as feature_id \
         FROM wasser.ebene_2km
@@ -183,9 +183,9 @@ source src_ch_bafu_wasser-teileinzugsgebiete_40 : def_queryable_features
             , 'feature' as origin \
             , 'ch.bafu.wasser-teileinzugsgebiete_40' as layer \
             , quadindex(the_geom) as geom_quadindex \
-            , y(st_transform(st_centroid(the_geom),4326)) as lat \
-            , x(st_transform(st_centroid(the_geom),4326)) as lon \
-            , st_box2d(the_geom) as geom_st_box2d \
+            , st_y(st_transform(st_centroid(the_geom),4326)) as lat \
+            , st_x(st_transform(st_centroid(the_geom),4326)) as lon \
+            , box2d(the_geom) as geom_st_box2d \
             , tezgnr40::text as label \
             , bgdi_id::text as feature_id \
         FROM wasser.ebene_40km
@@ -199,9 +199,9 @@ source src_ch_bafu_wasser-vorfluter : def_queryable_features
             , 'feature' as origin \
             , 'ch.bafu.wasser-vorfluter' as layer \
             , quadindex(the_geom) as geom_quadindex \
-            , y(st_transform(st_centroid(the_geom),4326)) as lat \
-            , x(st_transform(st_centroid(the_geom),4326)) as lon \
-            , st_box2d(the_geom) as geom_st_box2d \
+            , st_y(st_transform(st_centroid(the_geom),4326)) as lat \
+            , st_x(st_transform(st_centroid(the_geom),4326)) as lon \
+            , box2d(the_geom) as geom_st_box2d \
             , teilezgnr::text as label \
             , bgdi_id::text as feature_id \
         FROM wasser.vorfluter
@@ -215,9 +215,9 @@ source src_ch_bafu_wasser-gebietsauslaesse : def_queryable_features
             , 'feature' as origin \
             , 'ch.bafu.wasser-gebietsauslaesse' as layer \
             , quadindex(the_geom) as geom_quadindex \
-            , y(st_transform(st_centroid(the_geom),4326)) as lat \
-            , x(st_transform(st_centroid(the_geom),4326)) as lon \
-            , st_box2d(the_geom) as geom_st_box2d \
+            , st_y(st_transform(st_centroid(the_geom),4326)) as lat \
+            , st_x(st_transform(st_centroid(the_geom),4326)) as lon \
+            , box2d(the_geom) as geom_st_box2d \
             , ezgnr::text as label \
             , bgdi_id::text as feature_id \
         FROM wasser.outlets
@@ -231,9 +231,9 @@ source src_ch_bafu_bundesinventare-bln : def_queryable_features
             , 'feature' as origin \
             , 'ch.bafu.bundesinventare-bln' as layer \
             , quadindex(the_geom) as geom_quadindex \
-            , y(st_transform(st_centroid(the_geom),4326)) as lat \
-            , x(st_transform(st_centroid(the_geom),4326)) as lon \
-            , st_box2d(the_geom) as geom_st_box2d \
+            , st_y(st_transform(st_centroid(the_geom),4326)) as lat \
+            , st_x(st_transform(st_centroid(the_geom),4326)) as lon \
+            , box2d(the_geom) as geom_st_box2d \
             , bln_name::text as label \
             , gid::text as feature_id \
         FROM bundinv.bln
@@ -247,9 +247,9 @@ source src_ch_bafu_bundesinventare-hochmoore_anhoerung : def_queryable_features
             , 'feature' as origin \
             , 'ch.bafu.bundesinventare-hochmoore_anhoerung' as layer \
             , quadindex(the_geom) as geom_quadindex \
-            , y(st_transform(st_centroid(the_geom),4326)) as lat \
-            , x(st_transform(st_centroid(the_geom),4326)) as lon \
-            , st_box2d(the_geom) as geom_st_box2d \
+            , st_y(st_transform(st_centroid(the_geom),4326)) as lat \
+            , st_x(st_transform(st_centroid(the_geom),4326)) as lon \
+            , box2d(the_geom) as geom_st_box2d \
             , obj_name::text as label \
             , bgdi_id::text as feature_id \
         FROM bundinv.hochmoore_anhoerung
@@ -263,9 +263,9 @@ source src_ch_bafu_bundesinventare-hochmoore : def_queryable_features
             , 'feature' as origin \
             , 'ch.bafu.bundesinventare-hochmoore' as layer \
             , quadindex(the_geom) as geom_quadindex \
-            , y(st_transform(st_centroid(the_geom),4326)) as lat \
-            , x(st_transform(st_centroid(the_geom),4326)) as lon \
-            , st_box2d(the_geom) as geom_st_box2d \
+            , st_y(st_transform(st_centroid(the_geom),4326)) as lat \
+            , st_x(st_transform(st_centroid(the_geom),4326)) as lon \
+            , box2d(the_geom) as geom_st_box2d \
             , hm_name::text as label \
             , gid::text as feature_id \
         FROM bundinv.hm
@@ -279,9 +279,9 @@ source src_ch_bafu_bundesinventare-jagdbanngebiete : def_queryable_features
             , 'feature' as origin \
             , 'ch.bafu.bundesinventare-jagdbanngebiete' as layer \
             , quadindex(the_geom) as geom_quadindex \
-            , y(st_transform(st_centroid(the_geom),4326)) as lat \
-            , x(st_transform(st_centroid(the_geom),4326)) as lon \
-            , st_box2d(the_geom) as geom_st_box2d \
+            , st_y(st_transform(st_centroid(the_geom),4326)) as lat \
+            , st_x(st_transform(st_centroid(the_geom),4326)) as lon \
+            , box2d(the_geom) as geom_st_box2d \
             , jb_name::text || ' (' || jb_kat::text ||')' as label \
             , gid::text as feature_id \
         FROM bundinv.jb
@@ -295,9 +295,9 @@ source src_ch_bafu_bundesinventare-moorlandschaften : def_queryable_features
             , 'feature' as origin \
             , 'ch.bafu.bundesinventare-moorlandschaften' as layer \
             , quadindex(the_geom) as geom_quadindex \
-            , y(st_transform(st_centroid(the_geom),4326)) as lat \
-            , x(st_transform(st_centroid(the_geom),4326)) as lon \
-            , st_box2d(the_geom) as geom_st_box2d \
+            , st_y(st_transform(st_centroid(the_geom),4326)) as lat \
+            , st_x(st_transform(st_centroid(the_geom),4326)) as lon \
+            , box2d(the_geom) as geom_st_box2d \
             , ml_name::text as label \
             , gid::text as feature_id \
         FROM bundinv.ml
@@ -311,9 +311,9 @@ source src_ch_bafu_bundesinventare-moorlandschaften_anhoerung : def_queryable_fe
             , 'feature' as origin \
             , 'ch.bafu.bundesinventare-moorlandschaften_anhoerung' as layer \
             , quadindex(the_geom) as geom_quadindex \
-            , y(st_transform(st_centroid(the_geom),4326)) as lat \
-            , x(st_transform(st_centroid(the_geom),4326)) as lon \
-            , st_box2d(the_geom) as geom_st_box2d \
+            , st_y(st_transform(st_centroid(the_geom),4326)) as lat \
+            , st_x(st_transform(st_centroid(the_geom),4326)) as lon \
+            , box2d(the_geom) as geom_st_box2d \
             , obj_name ::text as label \
             , bgdi_id::text as feature_id \
         FROM bundinv.moorlandschaften_anhoerung
@@ -327,9 +327,9 @@ source src_ch_bafu_bundesinventare-vogelreservate : def_queryable_features
             , 'feature' as origin \
             , 'ch.bafu.bundesinventare-vogelreservate' as layer \
             , quadindex(the_geom) as geom_quadindex \
-            , y(st_transform(st_centroid(the_geom),4326)) as lat \
-            , x(st_transform(st_centroid(the_geom),4326)) as lon \
-            , st_box2d(the_geom) as geom_st_box2d \
+            , st_y(st_transform(st_centroid(the_geom),4326)) as lat \
+            , st_x(st_transform(st_centroid(the_geom),4326)) as lon \
+            , box2d(the_geom) as geom_st_box2d \
             , wv_name::text as label \
             , gid::text as feature_id \
         FROM bundinv.wv
@@ -343,9 +343,9 @@ source src_ch_bafu_wasser-entnahme_1 : def_queryable_features
             , 'feature' as origin \
             , 'ch.bafu.wasser-entnahme' as layer \
             , quadindex(the_geom) as geom_quadindex \
-            , y(st_transform(st_centroid(the_geom),4326)) as lat \
-            , x(st_transform(st_centroid(the_geom),4326)) as lon \
-            , st_box2d(the_geom) as geom_st_box2d \
+            , st_y(st_transform(st_centroid(the_geom),4326)) as lat \
+            , st_x(st_transform(st_centroid(the_geom),4326)) as lon \
+            , box2d(the_geom) as geom_st_box2d \
             , rwknr::text as label \
             , gid::text as feature_id \
         FROM wasser.invent_ent_wknutz_bedeutend
@@ -359,9 +359,9 @@ source src_ch_bafu_wasser-entnahme_2 : def_queryable_features
             , 'feature' as origin \
             , 'ch.bafu.wasser-entnahme' as layer \
             , quadindex(the_geom) as geom_quadindex \
-            , y(st_transform(st_centroid(the_geom),4326)) as lat \
-            , x(st_transform(st_centroid(the_geom),4326)) as lon \
-            , st_box2d(the_geom) as geom_st_box2d \
+            , st_y(st_transform(st_centroid(the_geom),4326)) as lat \
+            , st_x(st_transform(st_centroid(the_geom),4326)) as lon \
+            , box2d(the_geom) as geom_st_box2d \
             , rwknr::text as label \
             , gid::text as feature_id \
         FROM wasser.invent_ent_wknutz_weitere
@@ -375,9 +375,9 @@ source src_ch_bafu_wasser-entnahme_3 : def_queryable_features
             , 'feature' as origin \
             , 'ch.bafu.wasser-entnahme' as layer \
             , quadindex(the_geom) as geom_quadindex \
-            , y(st_transform(st_centroid(the_geom),4326)) as lat \
-            , x(st_transform(st_centroid(the_geom),4326)) as lon \
-            , st_box2d(the_geom) as geom_st_box2d \
+            , st_y(st_transform(st_centroid(the_geom),4326)) as lat \
+            , st_x(st_transform(st_centroid(the_geom),4326)) as lon \
+            , box2d(the_geom) as geom_st_box2d \
             , rwknr::text as label \
             , gid::text as feature_id \
         FROM wasser.invent_ent_andere_bedeutend
@@ -391,9 +391,9 @@ source src_ch_bafu_wasser-entnahme_4 : def_queryable_features
             , 'feature' as origin \
             , 'ch.bafu.wasser-entnahme' as layer \
             , quadindex(the_geom) as geom_quadindex \
-            , y(st_transform(st_centroid(the_geom),4326)) as lat \
-            , x(st_transform(st_centroid(the_geom),4326)) as lon \
-            , st_box2d(the_geom) as geom_st_box2d \
+            , st_y(st_transform(st_centroid(the_geom),4326)) as lat \
+            , st_x(st_transform(st_centroid(the_geom),4326)) as lon \
+            , box2d(the_geom) as geom_st_box2d \
             , rwknr::text as label \
             , gid::text as feature_id \
         FROM wasser.invent_ent_andere_weitere
@@ -407,9 +407,9 @@ source src_ch_bafu_wasser-leitungen : def_queryable_features
             , 'feature' as origin \
             , 'ch.bafu.wasser-leitungen' as layer \
             , quadindex(the_geom) as geom_quadindex \
-            , y(st_transform(st_centroid(the_geom),4326)) as lat \
-            , x(st_transform(st_centroid(the_geom),4326)) as lon \
-            , st_box2d(the_geom) as geom_st_box2d \
+            , st_y(st_transform(st_centroid(the_geom),4326)) as lat \
+            , st_x(st_transform(st_centroid(the_geom),4326)) as lon \
+            , box2d(the_geom) as geom_st_box2d \
             , rwknr::text as label \
             , gid::text as feature_id \
         FROM wasser.leitungen
@@ -423,9 +423,9 @@ source src_ch_bafu_wasser-rueckgabe : def_queryable_features
             , 'feature' as origin \
             , 'ch.bafu.wasser-rueckgabe' as layer \
             , quadindex(the_geom) as geom_quadindex \
-            , y(st_transform(st_centroid(the_geom),4326)) as lat \
-            , x(st_transform(st_centroid(the_geom),4326)) as lon \
-            , st_box2d(the_geom) as geom_st_box2d \
+            , st_y(st_transform(st_centroid(the_geom),4326)) as lat \
+            , st_x(st_transform(st_centroid(the_geom),4326)) as lon \
+            , box2d(the_geom) as geom_st_box2d \
             , rwknr::text as label \
             , gid::text as feature_id \
         FROM wasser.rueckgabe
@@ -439,9 +439,9 @@ source src_ch_bafu_bundesinventare-flachmoore : def_queryable_features
             , 'feature' as origin \
             , 'ch.bafu.bundesinventare-flachmoore' as layer \
             , quadindex(the_geom) as geom_quadindex \
-            , y(st_transform(st_centroid(the_geom),4326)) as lat \
-            , x(st_transform(st_centroid(the_geom),4326)) as lon \
-            , st_box2d(the_geom) as geom_st_box2d \
+            , st_y(st_transform(st_centroid(the_geom),4326)) as lat \
+            , st_x(st_transform(st_centroid(the_geom),4326)) as lon \
+            , box2d(the_geom) as geom_st_box2d \
             , fm_name::text as label \
             , gid::text as feature_id \
         FROM bundinv.fm
@@ -455,9 +455,9 @@ source src_ch_bafu_bundesinventare-flachmoore_anhoerung : def_queryable_features
             , 'feature' as origin \
             , 'ch.bafu.bundesinventare-flachmoore_anhoerung' as layer \
             , quadindex(the_geom) as geom_quadindex \
-            , y(st_transform(st_centroid(the_geom),4326)) as lat \
-            , x(st_transform(st_centroid(the_geom),4326)) as lon \
-            , st_box2d(the_geom) as geom_st_box2d \
+            , st_y(st_transform(st_centroid(the_geom),4326)) as lat \
+            , st_x(st_transform(st_centroid(the_geom),4326)) as lon \
+            , box2d(the_geom) as geom_st_box2d \
             , obj_name::text as label \
             , bgdi_id::text as feature_id \
         FROM bundinv.flachmoore_anhoerung
@@ -471,9 +471,9 @@ source src_ch_bafu_bundesinventare-flachmoore_regional : def_queryable_features
             , 'feature' as origin \
             , 'ch.bafu.bundesinventare-flachmoore_regional' as layer \
             , quadindex(the_geom) as geom_quadindex \
-            , y(st_transform(st_centroid(the_geom),4326)) as lat \
-            , x(st_transform(st_centroid(the_geom),4326)) as lon \
-            , st_box2d(the_geom) as geom_st_box2d \
+            , st_y(st_transform(st_centroid(the_geom),4326)) as lat \
+            , st_x(st_transform(st_centroid(the_geom),4326)) as lon \
+            , box2d(the_geom) as geom_st_box2d \
             , fmreg_name::text as label \
             , bgdi_id::text as feature_id \
         FROM bundinv.flachmoore_regional
@@ -487,9 +487,9 @@ source src_ch_bafu_schutzgebiete-paerke_nationaler_bedeutung : def_queryable_fea
             , 'feature' as origin \
             , 'ch.bafu.schutzgebiete-paerke_nationaler_bedeutung' as layer \
             , quadindex(the_geom) as geom_quadindex \
-            , y(st_transform(st_centroid(the_geom),4326)) as lat \
-            , x(st_transform(st_centroid(the_geom),4326)) as lon \
-            , st_box2d(the_geom) as geom_st_box2d \
+            , st_y(st_transform(st_centroid(the_geom),4326)) as lat \
+            , st_x(st_transform(st_centroid(the_geom),4326)) as lon \
+            , box2d(the_geom) as geom_st_box2d \
             , park_name::text as label \
             , bgdi_id::text as feature_id \
         FROM schutzge.paerke_nationaler_bedeutung
@@ -503,9 +503,9 @@ source src_ch_bafu_schutzgebiete-ramsar : def_queryable_features
             , 'feature' as origin \
             , 'ch.bafu.schutzgebiete-ramsar' as layer \
             , quadindex(the_geom) as geom_quadindex \
-            , y(st_transform(st_centroid(the_geom),4326)) as lat \
-            , x(st_transform(st_centroid(the_geom),4326)) as lon \
-            , st_box2d(the_geom) as geom_st_box2d \
+            , st_y(st_transform(st_centroid(the_geom),4326)) as lat \
+            , st_x(st_transform(st_centroid(the_geom),4326)) as lon \
+            , box2d(the_geom) as geom_st_box2d \
             , ra_name::text as label \
             , ra_id::text as feature_id \
         FROM schutzge.ramsar
@@ -519,9 +519,9 @@ source src_ch_bafu_wildruhezonen-jagdbanngebiete : def_queryable_features
             , 'feature' as origin \
             , 'ch.bafu.wildruhezonen-jagdbanngebiete' as layer \
             , quadindex(the_geom) as geom_quadindex \
-            , y(st_transform(st_centroid(the_geom),4326)) as lat \
-            , x(st_transform(st_centroid(the_geom),4326)) as lon \
-            , st_box2d(the_geom) as geom_st_box2d \
+            , st_y(st_transform(st_centroid(the_geom),4326)) as lat \
+            , st_x(st_transform(st_centroid(the_geom),4326)) as lon \
+            , box2d(the_geom) as geom_st_box2d \
             , wrz_name::text as label \
             , wrz_jb_obj::text as feature_id \
         FROM schutzge.wildruhezonen_jagdbanngebiete
@@ -535,9 +535,9 @@ source src_ch_bafu_wege-wildruhezonen-jagdbanngebiete : def_queryable_features
             , 'feature' as origin \
             , 'ch.bafu.wege-wildruhezonen-jagdbanngebiete' as layer \
             , quadindex(the_geom) as geom_quadindex \
-            , y(st_transform(st_centroid(the_geom),4326)) as lat \
-            , x(st_transform(st_centroid(the_geom),4326)) as lon \
-            , st_box2d(the_geom) as geom_st_box2d \
+            , st_y(st_transform(st_centroid(the_geom),4326)) as lat \
+            , st_x(st_transform(st_centroid(the_geom),4326)) as lon \
+            , box2d(the_geom) as geom_st_box2d \
             , wrz_obj::text as label \
             , weg_id::text as feature_id \
         FROM schutzge.wege_wildruhezonen_jagdbanngebiete
@@ -551,9 +551,9 @@ source src_ch_bafu_fauna-steinbockkolonien : def_queryable_features
             , 'feature' as origin \
             , 'ch.bafu.fauna-steinbockkolonien' as layer \
             , quadindex(the_geom) as geom_quadindex \
-            , y(st_transform(st_centroid(the_geom),4326)) as lat \
-            , x(st_transform(st_centroid(the_geom),4326)) as lon \
-            , st_box2d(the_geom) as geom_st_box2d \
+            , st_y(st_transform(st_centroid(the_geom),4326)) as lat \
+            , st_x(st_transform(st_centroid(the_geom),4326)) as lon \
+            , box2d(the_geom) as geom_st_box2d \
             , sb_name::text as label \
             , gid::text as feature_id \
         FROM fauna.sb
@@ -567,9 +567,9 @@ source src_ch_bafu_swissprtr : def_queryable_features
             , 'feature' as origin \
             , 'ch.bafu.swissprtr' as layer \
             , quadindex(the_geom) as geom_quadindex \
-            , y(st_transform(st_centroid(the_geom),4326)) as lat \
-            , x(st_transform(st_centroid(the_geom),4326)) as lon \
-            , st_box2d(the_geom) as geom_st_box2d \
+            , st_y(st_transform(st_centroid(the_geom),4326)) as lat \
+            , st_x(st_transform(st_centroid(the_geom),4326)) as lon \
+            , box2d(the_geom) as geom_st_box2d \
             , betrieb::text as label \
             , prtrnr::text as feature_id \
         FROM prtr.swissprtr
@@ -583,9 +583,9 @@ source src_ch_bafu_holzvorrat : def_queryable_features
             , 'feature' as origin \
             , 'ch.bafu.holzvorrat' as layer \
             , quadindex(the_geom) as geom_quadindex \
-            , y(st_transform(st_centroid(the_geom),4326)) as lat \
-            , x(st_transform(st_centroid(the_geom),4326)) as lon \
-            , st_box2d(the_geom) as geom_st_box2d \
+            , st_y(st_transform(st_centroid(the_geom),4326)) as lat \
+            , st_x(st_transform(st_centroid(the_geom),4326)) as lon \
+            , box2d(the_geom) as geom_st_box2d \
             , wireg_::text as label \
             , gid::text as feature_id \
         FROM wald.holzvorrat
@@ -599,9 +599,9 @@ source src_ch_bafu_holzzuwachs : def_queryable_features
             , 'feature' as origin \
             , 'ch.bafu.holzzuwachs' as layer \
             , quadindex(the_geom) as geom_quadindex \
-            , y(st_transform(st_centroid(the_geom),4326)) as lat \
-            , x(st_transform(st_centroid(the_geom),4326)) as lon \
-            , st_box2d(the_geom) as geom_st_box2d \
+            , st_y(st_transform(st_centroid(the_geom),4326)) as lat \
+            , st_x(st_transform(st_centroid(the_geom),4326)) as lon \
+            , box2d(the_geom) as geom_st_box2d \
             , wirtschaftsregion::text as label \
             , gid::text as feature_id \
         FROM wald.holzzuwachs
@@ -615,9 +615,9 @@ source src_ch_bafu_holznutzung : def_queryable_features
             , 'feature' as origin \
             , 'ch.bafu.holznutzung' as layer \
             , quadindex(the_geom) as geom_quadindex \
-            , y(st_transform(st_centroid(the_geom),4326)) as lat \
-            , x(st_transform(st_centroid(the_geom),4326)) as lon \
-            , st_box2d(the_geom) as geom_st_box2d \
+            , st_y(st_transform(st_centroid(the_geom),4326)) as lat \
+            , st_x(st_transform(st_centroid(the_geom),4326)) as lon \
+            , box2d(the_geom) as geom_st_box2d \
             , wireg_::text as label \
             , gid::text as feature_id \
         FROM wald.holznutzung
@@ -631,9 +631,9 @@ source src_ch_bafu_nabelstationen : def_queryable_features
             , 'feature' as origin \
             , 'ch.bafu.nabelstationen' as layer \
             , quadindex(the_geom) as geom_quadindex \
-            , y(st_transform(st_centroid(the_geom),4326)) as lat \
-            , x(st_transform(st_centroid(the_geom),4326)) as lon \
-            , st_box2d(the_geom) as geom_st_box2d \
+            , st_y(st_transform(st_centroid(the_geom),4326)) as lat \
+            , st_x(st_transform(st_centroid(the_geom),4326)) as lon \
+            , box2d(the_geom) as geom_st_box2d \
             , name::text as label \
             , id_stat::text as feature_id \
         FROM luft.nabel
@@ -647,9 +647,9 @@ source src_ch_bafu_fischerei-krebspest : def_queryable_features
             , 'feature' as origin \
             , 'ch.bafu.fischerei-krebspest' as layer \
             , quadindex(the_geom) as geom_quadindex \
-            , y(st_transform(st_centroid(the_geom),4326)) as lat \
-            , x(st_transform(st_centroid(the_geom),4326)) as lon \
-            , st_box2d(the_geom) as geom_st_box2d \
+            , st_y(st_transform(st_centroid(the_geom),4326)) as lat \
+            , st_x(st_transform(st_centroid(the_geom),4326)) as lon \
+            , box2d(the_geom) as geom_st_box2d \
             , kennummer::text as label \
             , _count::text as feature_id \
         FROM fischerei.krebspest
@@ -663,9 +663,9 @@ source src_ch_bafu_biogeographische_regionen : def_queryable_features
             , 'feature' as origin \
             , 'ch.bafu.biogeographische_regionen' as layer \
             , quadindex(the_geom) as geom_quadindex \
-            , y(st_transform(st_centroid(the_geom),4326)) as lat \
-            , x(st_transform(st_centroid(the_geom),4326)) as lon \
-            , st_box2d(the_geom) as geom_st_box2d \
+            , st_y(st_transform(st_centroid(the_geom),4326)) as lat \
+            , st_x(st_transform(st_centroid(the_geom),4326)) as lon \
+            , box2d(the_geom) as geom_st_box2d \
             , biogreg_r1::text as label \
             , bgdi_id::text as feature_id \
         FROM diverse.biogeoreg
@@ -679,9 +679,9 @@ source src_ch_bafu_schutzgebiete-smaragd : def_queryable_features
             , 'feature' as origin \
             , 'ch.bafu.schutzgebiete-smaragd' as layer \
             , quadindex(the_geom) as geom_quadindex \
-            , y(st_transform(st_centroid(the_geom),4326)) as lat \
-            , x(st_transform(st_centroid(the_geom),4326)) as lon \
-            , st_box2d(the_geom) as geom_st_box2d \
+            , st_y(st_transform(st_centroid(the_geom),4326)) as lat \
+            , st_x(st_transform(st_centroid(the_geom),4326)) as lon \
+            , box2d(the_geom) as geom_st_box2d \
             , em_name::text as label \
             , id::text as feature_id \
         FROM schutzge.smaragd
@@ -695,9 +695,9 @@ source src_ch_bafu_schutzgebiete-biosphaerenreservate : def_queryable_features
             , 'feature' as origin \
             , 'ch.bafu.schutzgebiete-biosphaerenreservate' as layer \
             , quadindex(the_geom) as geom_quadindex \
-            , y(st_transform(st_centroid(the_geom),4326)) as lat \
-            , x(st_transform(st_centroid(the_geom),4326)) as lon \
-            , st_box2d(the_geom) as geom_st_box2d \
+            , st_y(st_transform(st_centroid(the_geom),4326)) as lat \
+            , st_x(st_transform(st_centroid(the_geom),4326)) as lon \
+            , box2d(the_geom) as geom_st_box2d \
             , biores_nam::text as label \
             , bgdi_id::text as feature_id \
         FROM schutzge.biores
@@ -711,9 +711,9 @@ source src_ch_bafu_moose : def_queryable_features
             , 'feature' as origin \
             , 'ch.bafu.moose' as layer \
             , quadindex(the_geom) as geom_quadindex \
-            , y(st_transform(st_centroid(the_geom),4326)) as lat \
-            , x(st_transform(st_centroid(the_geom),4326)) as lon \
-            , st_box2d(the_geom) as geom_st_box2d \
+            , st_y(st_transform(st_centroid(the_geom),4326)) as lat \
+            , st_x(st_transform(st_centroid(the_geom),4326)) as lon \
+            , box2d(the_geom) as geom_st_box2d \
             , genus::text as label \
             , bgdi_id::text as feature_id \
         FROM flora.mooseflora
@@ -727,9 +727,9 @@ source src_ch_bafu_flora-weltensutter_atlas : def_queryable_features
             , 'feature' as origin \
             , 'ch.bafu.flora-weltensutter_atlas' as layer \
             , quadindex(the_geom) as geom_quadindex \
-            , y(st_transform(st_centroid(the_geom),4326)) as lat \
-            , x(st_transform(st_centroid(the_geom),4326)) as lon \
-            , st_box2d(the_geom) as geom_st_box2d \
+            , st_y(st_transform(st_centroid(the_geom),4326)) as lat \
+            , st_x(st_transform(st_centroid(the_geom),4326)) as lon \
+            , box2d(the_geom) as geom_st_box2d \
             , nom::text as label \
             , gid::text as feature_id \
         FROM flora.ws
@@ -743,9 +743,9 @@ source src_ch_bafu_landesforstinventar-baumarten : def_queryable_features
             , 'feature' as origin \
             , 'ch.bafu.landesforstinventar-baumarten' as layer \
             , quadindex(the_geom) as geom_quadindex \
-            , y(st_transform(st_centroid(the_geom),4326)) as lat \
-            , x(st_transform(st_centroid(the_geom),4326)) as lon \
-            , st_box2d(the_geom) as geom_st_box2d \
+            , st_y(st_transform(st_centroid(the_geom),4326)) as lat \
+            , st_x(st_transform(st_centroid(the_geom),4326)) as lon \
+            , box2d(the_geom) as geom_st_box2d \
             , wirtschaft::text as label \
             , bgdi_id::text as feature_id \
         FROM wald.baumartenmischung
@@ -759,9 +759,9 @@ source src_ch_bafu_landesforstinventar-waldanteil : def_queryable_features
             , 'feature' as origin \
             , 'ch.bafu.landesforstinventar-waldanteil' as layer \
             , quadindex(the_geom) as geom_quadindex \
-            , y(st_transform(st_centroid(the_geom),4326)) as lat \
-            , x(st_transform(st_centroid(the_geom),4326)) as lon \
-            , st_box2d(the_geom) as geom_st_box2d \
+            , st_y(st_transform(st_centroid(the_geom),4326)) as lat \
+            , st_x(st_transform(st_centroid(the_geom),4326)) as lon \
+            , box2d(the_geom) as geom_st_box2d \
             , wirtschaft::text as label \
             , bgdi_id::text as feature_id \
         FROM wald.waldanteil
@@ -775,9 +775,9 @@ source src_ch_bafu_landesforstinventar-totholz : def_queryable_features
             , 'feature' as origin \
             , 'ch.bafu.landesforstinventar-totholz' as layer \
             , quadindex(the_geom) as geom_quadindex \
-            , y(st_transform(st_centroid(the_geom),4326)) as lat \
-            , x(st_transform(st_centroid(the_geom),4326)) as lon \
-            , st_box2d(the_geom) as geom_st_box2d \
+            , st_y(st_transform(st_centroid(the_geom),4326)) as lat \
+            , st_x(st_transform(st_centroid(the_geom),4326)) as lon \
+            , box2d(the_geom) as geom_st_box2d \
             , wirtschaft::text as label \
             , bgdi_id::text as feature_id \
         FROM wald.totholzvolumen
@@ -791,9 +791,9 @@ source src_ch_bafu_gefahren-historische_erdbeben : def_queryable_features
             , 'feature' as origin \
             , 'ch.bafu.gefahren-historische_erdbeben' as layer \
             , quadindex(the_geom) as geom_quadindex \
-            , y(st_transform(st_centroid(the_geom),4326)) as lat \
-            , x(st_transform(st_centroid(the_geom),4326)) as lon \
-            , st_box2d(the_geom) as geom_st_box2d \
+            , st_y(st_transform(st_centroid(the_geom),4326)) as lat \
+            , st_x(st_transform(st_centroid(the_geom),4326)) as lon \
+            , box2d(the_geom) as geom_st_box2d \
             , date_time::text as label \
             , bgdi_id::text as feature_id \
         FROM gefahren.historische_erdbeben
@@ -807,9 +807,9 @@ source src_ch_bafu_gefahren-spektral : def_queryable_features
             , 'feature' as origin \
             , 'ch.bafu.gefahren-spektral' as layer \
             , quadindex(the_geom) as geom_quadindex \
-            , y(st_transform(st_centroid(the_geom),4326)) as lat \
-            , x(st_transform(st_centroid(the_geom),4326)) as lon \
-            , st_box2d(the_geom) as geom_st_box2d \
+            , st_y(st_transform(st_centroid(the_geom),4326)) as lat \
+            , st_x(st_transform(st_centroid(the_geom),4326)) as lon \
+            , box2d(the_geom) as geom_st_box2d \
             , id::text as label \
             , _count::text as feature_id \
         FROM gefahren.baugrundkl_spectral
@@ -823,9 +823,9 @@ source src_ch_bafu_bundesinventare-trockenwiesen_trockenweiden_anh : def_queryab
             , 'feature' as origin  \
             , 'ch.bafu.bundesinventare-trockenwiesen_trockenweiden_anhoerung' as layer  \
             , quadindex(the_geom) as geom_quadindex  \
-            , y(st_transform(st_centroid(the_geom),4326)) as lat  \
-            , x(st_transform(st_centroid(the_geom),4326)) as lon  \
-            , st_box2d(the_geom) as geom_st_box2d  \
+            , st_y(st_transform(st_centroid(the_geom),4326)) as lat  \
+            , st_x(st_transform(st_centroid(the_geom),4326)) as lon  \
+            , box2d(the_geom) as geom_st_box2d  \
             , obj_name::text as label  \
             , bgdi_id::text as feature_id  \
         FROM bundinv.trockenwiesen_trockenweiden_anhoerung
@@ -839,9 +839,9 @@ source src_ch_bafu_bundesinventare-trockenwiesen_trockenweiden : def_queryable_f
             , 'feature' as origin \
             , 'ch.bafu.bundesinventare-trockenwiesen_trockenweiden' as layer \
             , quadindex(the_geom) as geom_quadindex \
-            , y(st_transform(st_centroid(the_geom),4326)) as lat \
-            , x(st_transform(st_centroid(the_geom),4326)) as lon \
-            , st_box2d(the_geom) as geom_st_box2d \
+            , st_y(st_transform(st_centroid(the_geom),4326)) as lat \
+            , st_x(st_transform(st_centroid(the_geom),4326)) as lon \
+            , box2d(the_geom) as geom_st_box2d \
             , tww_name::text as label \
             , bgdi_id::text as feature_id \
         FROM bundinv.tww
@@ -855,9 +855,9 @@ source src_ch_bafu_bundesinventare-trockenwiesen_trockenweiden_anhang2 : def_que
             , 'feature' as origin \
             , 'ch.bafu.bundesinventare-trockenwiesen_trockenweiden_anhang2' as layer \
             , quadindex(the_geom) as geom_quadindex \
-            , y(st_transform(st_centroid(the_geom),4326)) as lat \
-            , x(st_transform(st_centroid(the_geom),4326)) as lon \
-            , st_box2d(the_geom) as geom_st_box2d \
+            , st_y(st_transform(st_centroid(the_geom),4326)) as lat \
+            , st_x(st_transform(st_centroid(the_geom),4326)) as lon \
+            , box2d(the_geom) as geom_st_box2d \
             , tww_name::text as label \
             , bgdi_id::text as feature_id \
         FROM bundinv.trockenwiesen_weiden_anhang2
@@ -871,9 +871,9 @@ source src_ch_bafu_bundesinventare-amphibien_anhang4 : def_queryable_features
             , 'feature' as origin \
             , 'ch.bafu.bundesinventare-amphibien_anhang4' as layer \
             , quadindex(the_geom) as geom_quadindex \
-            , y(st_transform(st_centroid(the_geom),4326)) as lat \
-            , x(st_transform(st_centroid(the_geom),4326)) as lon \
-            , st_box2d(the_geom) as geom_st_box2d \
+            , st_y(st_transform(st_centroid(the_geom),4326)) as lat \
+            , st_x(st_transform(st_centroid(the_geom),4326)) as lon \
+            , box2d(the_geom) as geom_st_box2d \
             , name::text as label \
             , bgdi_id::text as feature_id \
         FROM bundinv.amphibien_anhang4
@@ -887,9 +887,9 @@ source src_ch_bafu_gefahren-baugrundklassen : def_queryable_features
             , 'feature' as origin \
             , 'ch.bafu.gefahren-baugrundklassen' as layer \
             , quadindex(the_geom) as geom_quadindex \
-            , y(st_transform(st_centroid(the_geom),4326)) as lat \
-            , x(st_transform(st_centroid(the_geom),4326)) as lon \
-            , st_box2d(the_geom) as geom_st_box2d \
+            , st_y(st_transform(st_centroid(the_geom),4326)) as lat \
+            , st_x(st_transform(st_centroid(the_geom),4326)) as lon \
+            , box2d(the_geom) as geom_st_box2d \
             , bgk::text as label \
             , _count::text as feature_id \
         FROM gefahren.baugrundklassen
@@ -903,9 +903,9 @@ source src_ch_bav_laerm-emissionplan_eisenbahn_2015 : def_queryable_features
             , 'feature' as origin \
             , 'ch.bav.laerm-emissionplan_eisenbahn_2015' as layer \
             , quadindex(the_geom) as geom_quadindex \
-            , y(st_transform(st_centroid(the_geom),4326)) as lat \
-            , x(st_transform(st_centroid(the_geom),4326)) as lon \
-            , st_box2d(the_geom) as geom_st_box2d \
+            , st_y(st_transform(st_centroid(the_geom),4326)) as lat \
+            , st_x(st_transform(st_centroid(the_geom),4326)) as lon \
+            , box2d(the_geom) as geom_st_box2d \
             , id::text as label \
             , id::text as feature_id \
         FROM diverse.laerm_emplan_bahn_2015
@@ -919,9 +919,9 @@ source src_ch_bafu_wrz-jagdbanngebiete_select : def_queryable_features
             , 'feature' as origin \
             , 'ch.bafu.wrz-jagdbanngebiete_select' as layer \
             , quadindex(the_geom) as geom_quadindex \
-            , y(st_transform(st_centroid(the_geom),4326)) as lat \
-            , x(st_transform(st_centroid(the_geom),4326)) as lon \
-            , st_box2d(the_geom) as geom_st_box2d \
+            , st_y(st_transform(st_centroid(the_geom),4326)) as lat \
+            , st_x(st_transform(st_centroid(the_geom),4326)) as lon \
+            , box2d(the_geom) as geom_st_box2d \
             , jb_name::text as label \
             , objectid::text as feature_id \
         FROM wrzportal.jgd_select
@@ -935,9 +935,9 @@ source src_ch_bafu_wrz-wildruhezonen_portal : def_queryable_features
             , 'feature' as origin \
             , 'ch.bafu.wrz-wildruhezonen_portal' as layer \
             , quadindex(the_geom) as geom_quadindex \
-            , y(st_transform(st_centroid(the_geom),4326)) as lat \
-            , x(st_transform(st_centroid(the_geom),4326)) as lon \
-            , st_box2d(the_geom) as geom_st_box2d \
+            , st_y(st_transform(st_centroid(the_geom),4326)) as lat \
+            , st_x(st_transform(st_centroid(the_geom),4326)) as lon \
+            , box2d(the_geom) as geom_st_box2d \
             , wrz_name::text as label \
             , objectid::text as feature_id \
         FROM wrzportal.wrz_portal
@@ -951,9 +951,9 @@ source src_ch_bafu_fauna-wildtierkorridor_national : def_queryable_features
             , 'feature' as origin \
             , 'ch.bafu.fauna-wildtierkorridor_national' as layer \
             , quadindex(the_geom) as geom_quadindex \
-            , y(st_transform(st_centroid(the_geom),4326)) as lat \
-            , x(st_transform(st_centroid(the_geom),4326)) as lon \
-            , st_box2d(the_geom) as geom_st_box2d \
+            , st_y(st_transform(st_centroid(the_geom),4326)) as lat \
+            , st_x(st_transform(st_centroid(the_geom),4326)) as lon \
+            , box2d(the_geom) as geom_st_box2d \
             , nr::text as label \
             , bgdi_id::text as feature_id \
         FROM fauna.wildtierkorridore
@@ -967,9 +967,9 @@ source src_ch_bafu_oekomorphologie-f_bauwerke : def_queryable_features
             , 'feature' as origin \
             , 'ch.bafu.oekomorphologie-f_bauwerke' as layer \
             , quadindex(the_geom) as geom_quadindex \
-            , y(st_transform(st_centroid(the_geom),4326)) as lat \
-            , x(st_transform(st_centroid(the_geom),4326)) as lon \
-            , st_box2d(the_geom) as geom_st_box2d \
+            , st_y(st_transform(st_centroid(the_geom),4326)) as lat \
+            , st_x(st_transform(st_centroid(the_geom),4326)) as lon \
+            , box2d(the_geom) as geom_st_box2d \
             , bauwnr::text as label \
             , bgdi_id::text as feature_id \
         FROM wasser.oekom_bauwerke
@@ -984,9 +984,9 @@ source src_ch_bafu_oekomorphologie-f_abschnitte : def_queryable_features
             , 'feature' as origin \
             , 'ch.bafu.oekomorphologie-f_abschnitte' as layer \
             , quadindex(the_geom) as geom_quadindex \
-            , y(st_transform(st_centroid(the_geom),4326)) as lat \
-            , x(st_transform(st_centroid(the_geom),4326)) as lon \
-            , st_box2d(the_geom) as geom_st_box2d \
+            , st_y(st_transform(st_centroid(the_geom),4326)) as lat \
+            , st_x(st_transform(st_centroid(the_geom),4326)) as lon \
+            , box2d(the_geom) as geom_st_box2d \
             , anfangsmass::text as label \
             , bgdi_id::text as feature_id \
         FROM wasser.oekom_abschnitte
@@ -1001,9 +1001,9 @@ source src_ch_bafu_oekomorphologie-f_abstuerze : def_queryable_features
             , 'feature' as origin \
             , 'ch.bafu.oekomorphologie-f_abstuerze' as layer \
             , quadindex(the_geom) as geom_quadindex \
-            , y(st_transform(st_centroid(the_geom),4326)) as lat \
-            , x(st_transform(st_centroid(the_geom),4326)) as lon \
-            , st_box2d(the_geom) as geom_st_box2d \
+            , st_y(st_transform(st_centroid(the_geom),4326)) as lat \
+            , st_x(st_transform(st_centroid(the_geom),4326)) as lon \
+            , box2d(the_geom) as geom_st_box2d \
             , abstnr::text as label \
             , bgdi_id::text as feature_id \
         FROM wasser.oekom_abstuerze
@@ -1022,9 +1022,9 @@ source src_ch_bafu_hydrologie-wassertemperaturmessstationen : def_searchable_fea
             , nr::text||' '||remove_accents(name) as detail \
             , 'ch.bafu.hydrologie-wassertemperaturmessstationen' as layer \
             , quadindex(the_geom) as geom_quadindex \
-            , y(st_transform(st_centroid(the_geom),4326)) as lat \
-            , x(st_transform(st_centroid(the_geom),4326)) as lon \
-            , st_box2d(the_geom) as geom_st_box2d \
+            , st_y(st_transform(st_centroid(the_geom),4326)) as lat \
+            , st_x(st_transform(st_centroid(the_geom),4326)) as lon \
+            , box2d(the_geom) as geom_st_box2d \
             , nr::text as feature_id \
         from hydrologie.temperaturmessnetz
 }
@@ -1039,9 +1039,9 @@ source src_ch_bafu_hydrologie-gewaesserzustandsmessstationen : def_searchable_fe
             , nr::text||' '||remove_accents(name)||' '||remove_accents(gewaesser) as detail \
             , 'ch.bafu.hydrologie-gewaesserzustandsmessstationen' as layer \
             , quadindex(the_geom) as geom_quadindex \
-            , y(st_transform(st_centroid(the_geom),4326)) as lat \
-            , x(st_transform(st_centroid(the_geom),4326)) as lon \
-            , st_box2d(the_geom) as geom_st_box2d \
+            , st_y(st_transform(st_centroid(the_geom),4326)) as lat \
+            , st_x(st_transform(st_centroid(the_geom),4326)) as lon \
+            , box2d(the_geom) as geom_st_box2d \
             , bgdi_id::bigint as feature_id \
         from hydrologie.dbgz
 }
@@ -1056,9 +1056,9 @@ source src_ch_bafu_bundesinventare-auen : def_searchable_features
             , au_obj::text||' '||remove_accents(au_name) as detail \
             , 'ch.bafu.bundesinventare-auen' as layer \
             , quadindex(the_geom) as geom_quadindex \
-            , y(st_transform(st_ClosestPoint(the_geom,st_centroid(the_geom)),4326)) as lat \
-            , x(st_transform(st_ClosestPoint(the_geom,st_centroid(the_geom)),4326)) as lon \
-            , st_box2d(the_geom) as geom_st_box2d \
+            , st_y(st_transform(st_ClosestPoint(the_geom,st_centroid(the_geom)),4326)) as lat \
+            , st_x(st_transform(st_ClosestPoint(the_geom,st_centroid(the_geom)),4326)) as lon \
+            , box2d(the_geom) as geom_st_box2d \
             , gid::text as feature_id \
         from bundinv.au
 }
@@ -1073,9 +1073,9 @@ source src_ch_bafu_waldreservate : def_searchable_features
             , objnummer::text||' '||remove_accents(name)||' '||obj_gisflaeche::text||' '||mcpfe_class as detail \
             , 'ch.bafu.waldreservate' as layer \
             , quadindex(the_geom) as geom_quadindex \
-            , y(st_transform(st_centroid(the_geom),4326)) as lat \
-            , x(st_transform(st_centroid(the_geom),4326)) as lon \
-            , st_box2d(the_geom) as geom_st_box2d \
+            , st_y(st_transform(st_centroid(the_geom),4326)) as lat \
+            , st_x(st_transform(st_centroid(the_geom),4326)) as lon \
+            , box2d(the_geom) as geom_st_box2d \
             , objnummer::text as feature_id \
         from wald.waldreservate
 }

--- a/conf/bak.conf.part
+++ b/conf/bak.conf.part
@@ -10,9 +10,9 @@ source src_ch_bak_bundesinventar-schuetzenswerte-ortsbilder : def_queryable_feat
             , 'feature' as origin \
             , 'ch.bak.bundesinventar-schuetzenswerte-ortsbilder' as layer \
             , quadindex(the_geom) as geom_quadindex \
-            , y(st_transform(st_centroid(the_geom),4326)) as lat \
-            , x(st_transform(st_centroid(the_geom),4326)) as lon \
-            , st_box2d(the_geom) as geom_st_box2d \
+            , st_y(st_transform(st_centroid(the_geom),4326)) as lat \
+            , st_x(st_transform(st_centroid(the_geom),4326)) as lon \
+            , box2d(the_geom) as geom_st_box2d \
             , ortsbildname ::text as label \
             , gid::text as feature_id \
         FROM public.isos
@@ -26,9 +26,9 @@ source src_ch_bak_schutzgebiete-unesco_weltkulturerbe : def_queryable_features
             , 'feature' as origin \
             , 'ch.bak.schutzgebiete-unesco_weltkulturerbe' as layer \
             , quadindex(the_geom) as geom_quadindex \
-            , y(st_transform(st_centroid(the_geom),4326)) as lat \
-            , x(st_transform(st_centroid(the_geom),4326)) as lon \
-            , st_box2d(the_geom) as geom_st_box2d \
+            , st_y(st_transform(st_centroid(the_geom),4326)) as lat \
+            , st_x(st_transform(st_centroid(the_geom),4326)) as lon \
+            , box2d(the_geom) as geom_st_box2d \
             , bgdi_name::text as label \
             , bgdi_id::text as feature_id \
         FROM public.unesco

--- a/conf/dritte.conf.part
+++ b/conf/dritte.conf.part
@@ -10,9 +10,9 @@ source src_ch_tamedia_schweizerfamilie-feuerstellen : def_queryable_features
             , 'feature' as origin \
             , 'ch.tamedia.schweizerfamilie-feuerstellen' as layer \
             , quadindex(the_geom) as geom_quadindex \
-            , y(st_transform(st_centroid(the_geom),4326)) as lat \
-            , x(st_transform(st_centroid(the_geom),4326)) as lon \
-            , st_box2d(the_geom) as geom_st_box2d \
+            , st_y(st_transform(st_centroid(the_geom),4326)) as lat \
+            , st_x(st_transform(st_centroid(the_geom),4326)) as lon \
+            , box2d(the_geom) as geom_st_box2d \
             , gemeinde::text as label \
             , nr::text as feature_id \
         FROM tamedia.feuerstellen
@@ -26,9 +26,9 @@ source src_ch_ensi_zonenplan-notfallschutz-kernanlagen : def_queryable_features
             , 'feature' as origin \
             , 'ch.ensi.zonenplan-notfallschutz-kernanlagen' as layer \
             , quadindex(the_geom) as geom_quadindex \
-            , y(st_transform(st_centroid(the_geom),4326)) as lat \
-            , x(st_transform(st_centroid(the_geom),4326)) as lon \
-            , st_box2d(the_geom) as geom_st_box2d \
+            , st_y(st_transform(st_centroid(the_geom),4326)) as lat \
+            , st_x(st_transform(st_centroid(the_geom),4326)) as lon \
+            , box2d(the_geom) as geom_st_box2d \
             , name::text as label \
             , nr::text as feature_id \
         FROM ensi.zonenplan_kernanlagen
@@ -46,9 +46,9 @@ source src_ch_pronatura_waldreservate : def_searchable_features
             , sg_nr::text||' '||remove_accents(name)||' '||obj_gisflaeche::text||' '||mcpfe as detail \
             , 'ch.pronatura.waldreservate' as layer \
             , quadindex(the_geom) as geom_quadindex \
-            , y(st_transform(st_centroid(the_geom),4326)) as lat \
-            , x(st_transform(st_centroid(the_geom),4326)) as lon \
-            , st_box2d(the_geom) as geom_st_box2d \
+            , st_y(st_transform(st_centroid(the_geom),4326)) as lat \
+            , st_x(st_transform(st_centroid(the_geom),4326)) as lon \
+            , box2d(the_geom) as geom_st_box2d \
             , sg_nr::text as feature_id \
         from pronatura.waldreservate
 }

--- a/conf/edi.conf.part
+++ b/conf/edi.conf.part
@@ -10,9 +10,9 @@ source src_ch_bag_zecken-fsme-faelle : def_queryable_features
             , 'feature' as origin \
             , 'ch.bag.zecken-fsme-faelle' as layer \
             , quadindex(the_geom) as geom_quadindex \
-            , y(st_transform(st_centroid(the_geom),4326)) as lat \
-            , x(st_transform(st_centroid(the_geom),4326)) as lon \
-            , st_box2d(the_geom) as geom_st_box2d \
+            , st_y(st_transform(st_centroid(the_geom),4326)) as lat \
+            , st_x(st_transform(st_centroid(the_geom),4326)) as lon \
+            , box2d(the_geom) as geom_st_box2d \
             , gemname::text as label \
             , bgdi_id::text as feature_id \
         FROM bag.fsme_faelle
@@ -26,9 +26,9 @@ source src_ch_bag_zecken-fsme-impfung : def_queryable_features
             , 'feature' as origin \
             , 'ch.bag.zecken-fsme-impfung' as layer \
             , quadindex(the_geom) as geom_quadindex \
-            , y(st_transform(st_centroid(the_geom),4326)) as lat \
-            , x(st_transform(st_centroid(the_geom),4326)) as lon \
-            , st_box2d(the_geom) as geom_st_box2d \
+            , st_y(st_transform(st_centroid(the_geom),4326)) as lat \
+            , st_x(st_transform(st_centroid(the_geom),4326)) as lon \
+            , box2d(the_geom) as geom_st_box2d \
             , gemname::text as label \
             , bgdi_id::text as feature_id \
         FROM bag.fsme_impfung

--- a/conf/evd.conf.part
+++ b/conf/evd.conf.part
@@ -10,9 +10,9 @@ source src_ch_blw_bodeneignung-kulturtyp : def_queryable_features
              , 'feature' as origin \
              , 'ch.blw.bodeneignung-kulturtyp' as layer \
              , quadindex(the_geom) as geom_quadindex \
-             , y(st_transform(st_centroid(the_geom),4326)) as lat \
-             , x(st_transform(st_centroid(the_geom),4326)) as lon \
-             , st_box2d(the_geom) as geom_st_box2d \
+             , st_y(st_transform(st_centroid(the_geom),4326)) as lat \
+             , st_x(st_transform(st_centroid(the_geom),4326)) as lon \
+             , box2d(the_geom) as geom_st_box2d \
              , symb_color::text as label \
              , bgdi_id::text as feature_id \
          FROM blw.bodeneignung

--- a/conf/kogis.conf.part
+++ b/conf/kogis.conf.part
@@ -10,9 +10,9 @@ source src_ch_swisstopo_fixpunkte-agnes : def_queryable_features
             , 'feature' as origin \
             , 'ch.swisstopo.fixpunkte-agnes' as layer \
             , quadindex(the_geom) as geom_quadindex \
-            , y(st_transform(st_centroid(the_geom),4326)) as lat \
-            , x(st_transform(st_centroid(the_geom),4326)) as lon \
-            , st_box2d(the_geom) as geom_st_box2d \
+            , st_y(st_transform(st_centroid(the_geom),4326)) as lat \
+            , st_x(st_transform(st_centroid(the_geom),4326)) as lon \
+            , box2d(the_geom) as geom_st_box2d \
             , no::text as label \
             , no::text as feature_id \
         FROM fpds.agnes
@@ -30,9 +30,9 @@ source src_ch_swisstopo_fixpunkte-lfp1 : def_searchable_features
             , remove_accents(pointid)||' '||remove_accents(nummer) as detail \
             , 'ch.swisstopo.fixpunkte-lfp1' as layer \
             , quadindex(the_geom) as geom_quadindex \
-            , y(st_transform(st_centroid(the_geom),4326)) as lat \
-            , x(st_transform(st_centroid(the_geom),4326)) as lon \
-            , st_box2d(the_geom) as geom_st_box2d \
+            , st_y(st_transform(st_centroid(the_geom),4326)) as lat \
+            , st_x(st_transform(st_centroid(the_geom),4326)) as lon \
+            , box2d(the_geom) as geom_st_box2d \
             , pointid::text as feature_id \
         from fpds.punkt_lage_lfp1
 }
@@ -47,9 +47,9 @@ source src_ch_swisstopo_fixpunkte-lfp2 : def_searchable_features
             , remove_accents(pointid)||' '||remove_accents(nummer) as detail \
             , 'ch.swisstopo.fixpunkte-lfp2' as layer \
             , quadindex(the_geom) as geom_quadindex \
-            , y(st_transform(st_centroid(the_geom),4326)) as lat \
-            , x(st_transform(st_centroid(the_geom),4326)) as lon \
-            , st_box2d(the_geom) as geom_st_box2d \
+            , st_y(st_transform(st_centroid(the_geom),4326)) as lat \
+            , st_x(st_transform(st_centroid(the_geom),4326)) as lon \
+            , box2d(the_geom) as geom_st_box2d \
             , pointid::text as feature_id \
         from fpds.punkt_lage_lfp2
 }
@@ -64,9 +64,9 @@ source src_ch_swisstopo_fixpunkte-hfp1 : def_searchable_features
             , remove_accents(pointid)||' '||remove_accents(nummer)||' '||remove_accents(bgdi_label) as detail \
             , 'ch.swisstopo.fixpunkte-hfp1' as layer \
             , quadindex(the_geom) as geom_quadindex \
-            , y(st_transform(st_centroid(the_geom),4326)) as lat \
-            , x(st_transform(st_centroid(the_geom),4326)) as lon \
-            , st_box2d(the_geom) as geom_st_box2d \
+            , st_y(st_transform(st_centroid(the_geom),4326)) as lat \
+            , st_x(st_transform(st_centroid(the_geom),4326)) as lon \
+            , box2d(the_geom) as geom_st_box2d \
             , pointid::text as feature_id \
         from fpds.punkt_hoehe_hfp1
 }
@@ -81,9 +81,9 @@ source src_ch_swisstopo_fixpunkte-hfp2 : def_searchable_features
             , remove_accents(pointid)||' '||remove_accents(nummer) as detail \
             , 'ch.swisstopo.fixpunkte-hfp2' as layer \
             , quadindex(the_geom) as geom_quadindex \
-            , y(st_transform(st_centroid(the_geom),4326)) as lat \
-            , x(st_transform(st_centroid(the_geom),4326)) as lon \
-            , st_box2d(the_geom) as geom_st_box2d \
+            , st_y(st_transform(st_centroid(the_geom),4326)) as lat \
+            , st_x(st_transform(st_centroid(the_geom),4326)) as lon \
+            , box2d(the_geom) as geom_st_box2d \
             , pointid::text as feature_id \
         from fpds.punkt_hoehe_hfp2
 }
@@ -97,9 +97,9 @@ source src_ch_bfs_gebaeude_wohnungs_register : def_searchable_features
             , remove_accents(coalesce(strname1::text,''))||' '||remove_accents(coalesce(deinr::text,''))||' '||remove_accents(coalesce(plz4::text,''))||' '||remove_accents(coalesce(plzname::text,''))||' '||remove_accents(coalesce(gdename::text,''))||' _'||remove_accents(coalesce(gdekt::text, ''))||'_'||' '||remove_accents(coalesce(egid::text,'')) as detail \
             , 'ch.bfs.gebaeude_wohnungs_register' as layer \
             , bgdi_quadindex as geom_quadindex \
-            , y(st_transform(st_centroid(the_geom),4326)) as lat \
-            , x(st_transform(st_centroid(the_geom),4326)) as lon \
-            , st_box2d(the_geom) as geom_st_box2d \
+            , st_y(st_transform(st_centroid(the_geom),4326)) as lat \
+            , st_x(st_transform(st_centroid(the_geom),4326)) as lon \
+            , box2d(the_geom) as geom_st_box2d \
             , coalesce(strname1,'')||' '||coalesce(deinr::text,'')||' '||coalesce(gdename,'') as label \
             , egid_edid::text as feature_id \
         FROM bfs.adr

--- a/conf/lubis.conf.part
+++ b/conf/lubis.conf.part
@@ -12,9 +12,9 @@ source src_ch_swisstopo_lubis-bildstreifen : def_searchable_features_with_year
             , bildstreifen_nr as detail \
             , 'ch.swisstopo.lubis-bildstreifen' as layer \
             , quadindex(the_geom) as geom_quadindex \
-            , y(st_transform(st_ClosestPoint(the_geom,st_centroid(the_geom)),4326)) as lat \
-            , x(st_transform(st_ClosestPoint(the_geom,st_centroid(the_geom)),4326)) as lon \
-            , st_box2d(the_geom) as geom_st_box2d \
+            , st_y(st_transform(st_ClosestPoint(the_geom,st_centroid(the_geom)),4326)) as lat \
+            , st_x(st_transform(st_ClosestPoint(the_geom,st_centroid(the_geom)),4326)) as lon \
+            , box2d(the_geom) as geom_st_box2d \
             , bgdi_flugjahr as year \
             , bildstreifen_nr::text as feature_id \
         FROM ads40.view_bildstreifen
@@ -30,9 +30,9 @@ source src_ch_swisstopo_lubis-luftbilder_farbe : def_searchable_features_with_ye
             , ebkey || ' ' || coalesce(ort,'')  as detail \
             , 'ch.swisstopo.lubis-luftbilder_farbe' as layer \
             , bgdi_quadindex as geom_quadindex \
-            , y(st_transform(st_centroid(the_geom),4326)) as lat \
-            , x(st_transform(st_centroid(the_geom),4326)) as lon \
-            , st_box2d(the_geom) as geom_st_box2d \
+            , st_y(st_transform(st_centroid(the_geom),4326)) as lat \
+            , st_x(st_transform(st_centroid(the_geom),4326)) as lon \
+            , box2d(the_geom) as geom_st_box2d \
             , bgdi_flugjahr as year \
             , ebkey::text as feature_id \
         from public.luftbilder_swisstopo_color
@@ -48,9 +48,9 @@ source src_ch_swisstopo_lubis-luftbilder_schwarzweiss: def_searchable_features_w
             , ebkey || ' ' || coalesce(ort,'')  as detail \
             , 'ch.swisstopo.lubis-luftbilder_schwarzweiss' as layer \
             , bgdi_quadindex as geom_quadindex \
-            , y(st_transform(st_centroid(the_geom),4326)) as lat \
-            , x(st_transform(st_centroid(the_geom),4326)) as lon \
-            , st_box2d(the_geom) as geom_st_box2d \
+            , st_y(st_transform(st_centroid(the_geom),4326)) as lat \
+            , st_x(st_transform(st_centroid(the_geom),4326)) as lon \
+            , box2d(the_geom) as geom_st_box2d \
             , bgdi_flugjahr as year \
             , ebkey::text as feature_id \
         from public.luftbilder_swisstopo_bw
@@ -66,9 +66,9 @@ source src_ch_swisstopo_lubis-luftbilder_infrarot: def_searchable_features_with_
             , ebkey || ' ' || coalesce(ort,'')  as detail \
             , 'ch.swisstopo.lubis-luftbilder_infrarot' as layer \
             , bgdi_quadindex as geom_quadindex \
-            , y(st_transform(st_centroid(the_geom),4326)) as lat \
-            , x(st_transform(st_centroid(the_geom),4326)) as lon \
-            , st_box2d(the_geom) as geom_st_box2d \
+            , st_y(st_transform(st_centroid(the_geom),4326)) as lat \
+            , st_x(st_transform(st_centroid(the_geom),4326)) as lon \
+            , box2d(the_geom) as geom_st_box2d \
             , bgdi_flugjahr as year \
             , ebkey::text as feature_id \
         from public.luftbilder_swisstopo_ir
@@ -84,9 +84,9 @@ source src_ch_swisstopo_lubis-luftbilder-dritte-kantone : def_searchable_feature
             , ebkey || ' ' || coalesce(ort,'')  as detail \
             , 'ch.swisstopo.lubis-luftbilder-dritte-kantone' as layer \
             , bgdi_quadindex as geom_quadindex \
-            , y(st_transform(st_centroid(the_geom),4326)) as lat \
-            , x(st_transform(st_centroid(the_geom),4326)) as lon \
-            , st_box2d(the_geom) as geom_st_box2d \
+            , st_y(st_transform(st_centroid(the_geom),4326)) as lat \
+            , st_x(st_transform(st_centroid(the_geom),4326)) as lon \
+            , box2d(the_geom) as geom_st_box2d \
             , bgdi_flugjahr as year \
             , ebkey::text as feature_id \
         from public.luftbilder_dritte_kantone
@@ -102,9 +102,9 @@ source src_ch_swisstopo_lubis-luftbilder-dritte-firmen : def_searchable_features
             , ebkey || ' ' || coalesce(ort,'')  as detail \
             , 'ch.swisstopo.lubis-luftbilder-dritte-firmen' as layer \
             , bgdi_quadindex as geom_quadindex \
-            , y(st_transform(st_centroid(the_geom),4326)) as lat \
-            , x(st_transform(st_centroid(the_geom),4326)) as lon \
-            , st_box2d(the_geom) as geom_st_box2d \
+            , st_y(st_transform(st_centroid(the_geom),4326)) as lat \
+            , st_x(st_transform(st_centroid(the_geom),4326)) as lon \
+            , box2d(the_geom) as geom_st_box2d \
             , bgdi_flugjahr as year \
             , ebkey::text as feature_id \
         FROM public.luftbilder_dritte_firmen

--- a/conf/search.conf.part
+++ b/conf/search.conf.part
@@ -30,8 +30,8 @@ source src_address : src_swisssearch
         , 6::integer as rank \
         , x \
         , y \
-        , y(st_transform(the_geom,4326)) as lat \
-        , x(st_transform(the_geom,4326)) as lon \
+        , st_y(st_transform(the_geom,4326)) as lat \
+        , st_x(st_transform(the_geom,4326)) as lon \
         , num \
         FROM bfs.adressen_sphinx
 }
@@ -50,8 +50,8 @@ source src_parcel : src_swisssearch
         , 10::integer as rank \
         , x \
         , y \
-        , y(st_transform(st_centroid(the_geom),4326)) as lat \
-        , x(st_transform(st_centroid(the_geom),4326)) as lon \
+        , st_y(st_transform(st_centroid(the_geom),4326)) as lat \
+        , st_x(st_transform(st_centroid(the_geom),4326)) as lon \
         , num \
         from kantone.parzellen_sphinx
 }
@@ -67,12 +67,12 @@ source src_sn25 : src_swisssearch
         , '<b>'||coalesce(name,'')||'</b> ('||coalesce(kanton,'')||') - '||coalesce(gemname,'') as label  \
         , 'sn25'::text as origin \
         , quadindex(the_geom) as geom_quadindex \
-        , st_box2d(the_geom) as geom_st_box2d \
+        , box2d(the_geom) as geom_st_box2d \
         , 5::integer as rank \
-        , y((the_geom)) as x \
-        , x((the_geom)) as y \
-        , y(st_transform(the_geom,4326)) as lat \
-        , x(st_transform(the_geom,4326)) as lon \
+        , st_y((the_geom)) as x \
+        , st_x((the_geom)) as y \
+        , st_y(st_transform(the_geom,4326)) as lat \
+        , st_x(st_transform(the_geom,4326)) as lon \
         , 1 as num \
         FROM tlm.swissnames_sn25_und_tlm
 }
@@ -88,12 +88,12 @@ source src_gg25 : src_swisssearch
         , '<b>'||coalesce(gemname,'')||' ('||coalesce(k.ak,'')||')</b>' as label \
         , 'gg25'::text as origin \
         , quadindex(g.the_geom) as geom_quadindex \
-        , st_box2d(g.the_geom) as geom_st_box2d \
+        , box2d(g.the_geom) as geom_st_box2d \
         , 2::integer as rank \
-        , y(ST_PointOnSurface(g.the_geom)) AS x \
-        , x(ST_PointOnSurface(g.the_geom)) AS y \
-        , y(st_transform(ST_PointOnSurface(g.the_geom),4326)) as lat \
-        , x(st_transform(ST_PointOnSurface(g.the_geom),4326)) as lon \
+        , st_y(ST_PointOnSurface(g.the_geom)) AS x \
+        , st_x(ST_PointOnSurface(g.the_geom)) AS y \
+        , st_y(st_transform(ST_PointOnSurface(g.the_geom),4326)) as lat \
+        , st_x(st_transform(ST_PointOnSurface(g.the_geom),4326)) as lon \
         , 1 as num \
         FROM tlm.swissboundaries_gemeinden_uebersetzt g left join tlm.swissboundaries_kantone k on k.kantonsnr = g.kantonsnr 
 }
@@ -109,12 +109,12 @@ source src_kantone : src_swisssearch
         , '<b>'||name||'</b>' as label \
         , 'kantone'::text as origin \
         , quadindex(the_geom) as geom_quadindex \
-        , st_box2d(the_geom) as geom_st_box2d \
+        , box2d(the_geom) as geom_st_box2d \
         , 4 as rank \
-        , y(ST_PointOnSurface(the_geom)) AS x \
-        , x(ST_PointOnSurface(the_geom)) AS y \
-        , y(st_transform(ST_PointOnSurface(the_geom),4326)) as lat \
-        , x(st_transform(ST_PointOnSurface(the_geom),4326)) as lon \
+        , st_y(ST_PointOnSurface(the_geom)) AS x \
+        , st_x(ST_PointOnSurface(the_geom)) AS y \
+        , st_y(st_transform(ST_PointOnSurface(the_geom),4326)) as lat \
+        , st_x(st_transform(ST_PointOnSurface(the_geom),4326)) as lon \
         , 1 as num \
          FROM tlm.swissboundaries_kantone
 }
@@ -131,12 +131,12 @@ source src_district : src_swisssearch
         , '<b>'||name||'</b>' as label \
         , 'district'::text as origin \
         , quadindex(the_geom) as geom_quadindex \
-        , st_box2d(the_geom) as geom_st_box2d \
+        , box2d(the_geom) as geom_st_box2d \
         , 3::integer as rank \
-        , y(ST_PointOnSurface(the_geom)) AS x \
-        , x(ST_PointOnSurface(the_geom)) AS y \
-        , y(st_transform(ST_PointOnSurface(the_geom),4326)) as lat \
-        , x(st_transform(ST_PointOnSurface(the_geom),4326)) as lon \
+        , st_y(ST_PointOnSurface(the_geom)) AS x \
+        , st_x(ST_PointOnSurface(the_geom)) AS y \
+        , st_y(st_transform(ST_PointOnSurface(the_geom),4326)) as lat \
+        , st_x(st_transform(ST_PointOnSurface(the_geom),4326)) as lon \
         , 1 as num \
         FROM tlm.swissboundaries_bezirke 
 }
@@ -152,12 +152,12 @@ source src_zipcode : src_swisssearch
         , '<b>'||coalesce(plz::text,'')||' - '||coalesce(langtext,'')||' ('||coalesce((SELECT ak from tlm.swissboundaries_kantone k where st_intersects(ST_PointOnSurface(p.the_geom),k.the_geom)),'')||')</b>' as label \
         , 'zipcode' as origin \
         , quadindex(the_geom) as geom_quadindex \
-        , st_box2d(the_geom) as geom_st_box2d\
+        , box2d(the_geom) as geom_st_box2d\
         , 1 as rank \
-        , y(ST_PointOnSurface(the_geom)) AS x \
-        , x(ST_PointOnSurface(the_geom)) AS y \
-        , y(st_transform(ST_PointOnSurface(the_geom),4326)) as lat \
-        , x(st_transform(ST_PointOnSurface(the_geom),4326)) as lon \
+        , st_y(ST_PointOnSurface(the_geom)) AS x \
+        , st_x(ST_PointOnSurface(the_geom)) AS y \
+        , st_y(st_transform(ST_PointOnSurface(the_geom),4326)) as lat \
+        , st_x(st_transform(ST_PointOnSurface(the_geom),4326)) as lon \
         , 1 as num \
         FROM vd.gabmo_plz p
 }

--- a/conf/stopo.conf.part
+++ b/conf/stopo.conf.part
@@ -12,9 +12,9 @@ source src_ch_kantone_cadastralwebmap-farbe : def_queryable_features
             , 'feature' as origin \
             , 'ch.kantone.cadastralwebmap-farbe' as layer \
             , quadindex(the_geom) as geom_quadindex \
-            , y(st_transform(st_centroid(the_geom),4326)) as lat \
-            , x(st_transform(st_centroid(the_geom),4326)) as lon \
-            , st_box2d(the_geom) as geom_st_box2d \
+            , st_y(st_transform(st_centroid(the_geom),4326)) as lat \
+            , st_x(st_transform(st_centroid(the_geom),4326)) as lon \
+            , box2d(the_geom) as geom_st_box2d \
             , ak::text as label \
             , gid::text as feature_id \
         FROM public.kantone25plus
@@ -28,9 +28,9 @@ source src_ch_swisstopo_vec200-transportation-oeffentliche-verkehr_1 : def_query
             , 'feature' as origin \
             , 'ch.swisstopo.vec200-transportation-oeffentliche-verkehr' as layer \
             , quadindex(the_geom) as geom_quadindex \
-            , y(st_transform(st_centroid(the_geom),4326)) as lat \
-            , x(st_transform(st_centroid(the_geom),4326)) as lon \
-            , st_box2d(the_geom) as geom_st_box2d \
+            , st_y(st_transform(st_centroid(the_geom),4326)) as lat \
+            , st_x(st_transform(st_centroid(the_geom),4326)) as lon \
+            , box2d(the_geom) as geom_st_box2d \
             , objval::text as label \
             , gtdboid::text as feature_id \
         FROM public.vec200_terminal
@@ -44,9 +44,9 @@ source src_ch_swisstopo_vec200-transportation-oeffentliche-verkehr_2 : def_query
             , 'feature' as origin \
             , 'ch.swisstopo.vec200-transportation-oeffentliche-verkehr' as layer \
             , quadindex(the_geom) as geom_quadindex \
-            , y(st_transform(st_centroid(the_geom),4326)) as lat \
-            , x(st_transform(st_centroid(the_geom),4326)) as lon \
-            , st_box2d(the_geom) as geom_st_box2d \
+            , st_y(st_transform(st_centroid(the_geom),4326)) as lat \
+            , st_x(st_transform(st_centroid(the_geom),4326)) as lon \
+            , box2d(the_geom) as geom_st_box2d \
             , objval::text as label \
             , gtdboid::text as feature_id \
         FROM public.v200_ship_kursschiff_linie_tooltip
@@ -60,9 +60,9 @@ source src_ch_swisstopo_vec200-transportation-oeffentliche-verkehr_3 : def_query
             , 'feature' as origin \
             , 'ch.swisstopo.vec200-transportation-oeffentliche-verkehr' as layer \
             , quadindex(the_geom) as geom_quadindex \
-            , y(st_transform(st_centroid(the_geom),4326)) as lat \
-            , x(st_transform(st_centroid(the_geom),4326)) as lon \
-            , st_box2d(the_geom) as geom_st_box2d \
+            , st_y(st_transform(st_centroid(the_geom),4326)) as lat \
+            , st_x(st_transform(st_centroid(the_geom),4326)) as lon \
+            , box2d(the_geom) as geom_st_box2d \
             , objval::text as label \
             , gtdboid::text as feature_id \
         FROM public.vec200_railway
@@ -76,9 +76,9 @@ source src_ch_swisstopo_treasurehunt : def_queryable_features
             , 'feature' as origin \
             , 'ch.swisstopo.treasurehunt' as layer \
             , quadindex(the_geom) as geom_quadindex \
-            , y(st_transform(st_centroid(the_geom),4326)) as lat \
-            , x(st_transform(st_centroid(the_geom),4326)) as lon \
-            , st_box2d(the_geom) as geom_st_box2d \
+            , st_y(st_transform(st_centroid(the_geom),4326)) as lat \
+            , st_x(st_transform(st_centroid(the_geom),4326)) as lon \
+            , box2d(the_geom) as geom_st_box2d \
             , title_de::text as label \
             , bgdi_id::text as feature_id \
         FROM public.treasurehunt
@@ -92,9 +92,9 @@ source src_ch_swisstopo_vec200-transportation-strassennetz_1 : def_queryable_fea
             , 'feature' as origin \
             , 'ch.swisstopo.vec200-transportation-strassennetz' as layer \
             , quadindex(the_geom) as geom_quadindex \
-            , y(st_transform(st_centroid(the_geom),4326)) as lat \
-            , x(st_transform(st_centroid(the_geom),4326)) as lon \
-            , st_box2d(the_geom) as geom_st_box2d \
+            , st_y(st_transform(st_centroid(the_geom),4326)) as lat \
+            , st_x(st_transform(st_centroid(the_geom),4326)) as lon \
+            , box2d(the_geom) as geom_st_box2d \
             , objname::text as label \
             , gtdboid::text as feature_id \
         FROM public.vec200_trafficinfo
@@ -108,9 +108,9 @@ source src_ch_swisstopo_vec200-transportation-strassennetz_2 : def_queryable_fea
             , 'feature' as origin \
             , 'ch.swisstopo.vec200-transportation-strassennetz' as layer \
             , quadindex(the_geom) as geom_quadindex \
-            , y(st_transform(st_centroid(the_geom),4326)) as lat \
-            , x(st_transform(st_centroid(the_geom),4326)) as lon \
-            , st_box2d(the_geom) as geom_st_box2d \
+            , st_y(st_transform(st_centroid(the_geom),4326)) as lat \
+            , st_x(st_transform(st_centroid(the_geom),4326)) as lon \
+            , box2d(the_geom) as geom_st_box2d \
             , detn::text as label \
             , gtdboid::text as feature_id \
         FROM public.v200_ship_autofaehre_tooltip
@@ -124,9 +124,9 @@ source src_ch_swisstopo_vec200-transportation-strassennetz_3 : def_queryable_fea
             , 'feature' as origin \
             , 'ch.swisstopo.vec200-transportation-strassennetz' as layer \
             , quadindex(the_geom) as geom_quadindex \
-            , y(st_transform(st_centroid(the_geom),4326)) as lat \
-            , x(st_transform(st_centroid(the_geom),4326)) as lon \
-            , st_box2d(the_geom) as geom_st_box2d \
+            , st_y(st_transform(st_centroid(the_geom),4326)) as lat \
+            , st_x(st_transform(st_centroid(the_geom),4326)) as lon \
+            , box2d(the_geom) as geom_st_box2d \
             , objval::text as label \
             , gtdboid::text as feature_id \
         FROM public.vec200_road
@@ -140,9 +140,9 @@ source src_ch_swisstopo_vec200-transportation-strassennetz_4 : def_queryable_fea
              , 'feature' as origin \
              , 'ch.swisstopo.vec200-transportation-strassennetz' as layer \
              , quadindex(the_geom) as geom_quadindex \
-             , y(st_transform(st_centroid(the_geom),4326)) as lat \
-             , x(st_transform(st_centroid(the_geom),4326)) as lon \
-             , st_box2d(the_geom) as geom_st_box2d \
+             , st_y(st_transform(st_centroid(the_geom),4326)) as lat \
+             , st_x(st_transform(st_centroid(the_geom),4326)) as lon \
+             , box2d(the_geom) as geom_st_box2d \
              , objval::text as label \
              , gtdboid::text as feature_id \
          FROM public.vec200_ramp
@@ -156,9 +156,9 @@ source src_ch_swisstopo_vec200-transportation-strassennetz_5 : def_queryable_fea
             , 'feature' as origin \
             , 'ch.swisstopo.vec200-transportation-strassennetz' as layer \
             , quadindex(the_geom) as geom_quadindex \
-            , y(st_transform(st_centroid(the_geom),4326)) as lat \
-            , x(st_transform(st_centroid(the_geom),4326)) as lon \
-            , st_box2d(the_geom) as geom_st_box2d \
+            , st_y(st_transform(st_centroid(the_geom),4326)) as lat \
+            , st_x(st_transform(st_centroid(the_geom),4326)) as lon \
+            , box2d(the_geom) as geom_st_box2d \
             , objname::text as label \
             , gtdboid::text as feature_id \
         FROM public.vec200_customsoffice
@@ -172,9 +172,9 @@ source src_ch_swisstopo_vec200-adminboundaries-protectedarea : def_queryable_fea
             , 'feature' as origin \
             , 'ch.swisstopo.vec200-adminboundaries-protectedarea' as layer \
             , quadindex(the_geom) as geom_quadindex \
-            , y(st_transform(st_centroid(the_geom),4326)) as lat \
-            , x(st_transform(st_centroid(the_geom),4326)) as lon \
-            , st_box2d(the_geom) as geom_st_box2d \
+            , st_y(st_transform(st_centroid(the_geom),4326)) as lat \
+            , st_x(st_transform(st_centroid(the_geom),4326)) as lon \
+            , box2d(the_geom) as geom_st_box2d \
             , name::text as label \
             , gtdboid::text as feature_id \
         FROM public.vec200_protectedarea
@@ -188,9 +188,9 @@ source src_ch_swisstopo_vec200-hydrography_1 : def_queryable_features
             , 'feature' as origin \
             , 'ch.swisstopo.vec200-hydrography' as layer \
             , quadindex(the_geom) as geom_quadindex \
-            , y(st_transform(st_centroid(the_geom),4326)) as lat \
-            , x(st_transform(st_centroid(the_geom),4326)) as lon \
-            , st_box2d(the_geom) as geom_st_box2d \
+            , st_y(st_transform(st_centroid(the_geom),4326)) as lat \
+            , st_x(st_transform(st_centroid(the_geom),4326)) as lon \
+            , box2d(the_geom) as geom_st_box2d \
             , name::text as label \
             , gtdboid::text as feature_id \
         FROM public.vec200_flowingwater
@@ -204,9 +204,9 @@ source src_ch_swisstopo_vec200-hydrography_2 : def_queryable_features
             , 'feature' as origin \
             , 'ch.swisstopo.vec200-hydrography' as layer \
             , quadindex(the_geom) as geom_quadindex \
-            , y(st_transform(st_centroid(the_geom),4326)) as lat \
-            , x(st_transform(st_centroid(the_geom),4326)) as lon \
-            , st_box2d(the_geom) as geom_st_box2d \
+            , st_y(st_transform(st_centroid(the_geom),4326)) as lat \
+            , st_x(st_transform(st_centroid(the_geom),4326)) as lon \
+            , box2d(the_geom) as geom_st_box2d \
             , name::text as label \
             , gtdboid::text as feature_id \
         FROM public.vec200_stagnantwater
@@ -220,9 +220,9 @@ source src_ch_swisstopo_vec200-landcover : def_queryable_features
             , 'feature' as origin \
             , 'ch.swisstopo.vec200-landcover' as layer \
             , quadindex(the_geom) as geom_quadindex \
-            , y(st_transform(st_centroid(the_geom),4326)) as lat \
-            , x(st_transform(st_centroid(the_geom),4326)) as lon \
-            , st_box2d(the_geom) as geom_st_box2d \
+            , st_y(st_transform(st_centroid(the_geom),4326)) as lat \
+            , st_x(st_transform(st_centroid(the_geom),4326)) as lon \
+            , box2d(the_geom) as geom_st_box2d \
             , objname1::text as label \
             , gtdboid::text as feature_id \
         FROM public.vec200_landcover
@@ -236,9 +236,9 @@ source src_ch_swisstopo_vec200-miscellaneous_1 : def_queryable_features
             , 'feature' as origin \
             , 'ch.swisstopo.vec200-miscellaneous' as layer \
             , quadindex(the_geom) as geom_quadindex \
-            , y(st_transform(st_centroid(the_geom),4326)) as lat \
-            , x(st_transform(st_centroid(the_geom),4326)) as lon \
-            , st_box2d(the_geom) as geom_st_box2d \
+            , st_y(st_transform(st_centroid(the_geom),4326)) as lat \
+            , st_x(st_transform(st_centroid(the_geom),4326)) as lon \
+            , box2d(the_geom) as geom_st_box2d \
             , objname::text as label \
             , gtdboid::text as feature_id \
         FROM public.vec200_builtupp
@@ -252,9 +252,9 @@ source src_ch_swisstopo_vec200-miscellaneous_2 : def_queryable_features
             , 'feature' as origin \
             , 'ch.swisstopo.vec200-miscellaneous' as layer \
             , quadindex(the_geom) as geom_quadindex \
-            , y(st_transform(st_centroid(the_geom),4326)) as lat \
-            , x(st_transform(st_centroid(the_geom),4326)) as lon \
-            , st_box2d(the_geom) as geom_st_box2d \
+            , st_y(st_transform(st_centroid(the_geom),4326)) as lat \
+            , st_x(st_transform(st_centroid(the_geom),4326)) as lon \
+            , box2d(the_geom) as geom_st_box2d \
             , objname::text as label \
             , gtdboid::text as feature_id \
         FROM public.v200_poi_tooltip
@@ -268,9 +268,9 @@ source src_ch_swisstopo_vec200-miscellaneous_3 : def_queryable_features
             , 'feature' as origin \
             , 'ch.swisstopo.vec200-miscellaneous' as layer \
             , quadindex(the_geom) as geom_quadindex \
-            , y(st_transform(st_centroid(the_geom),4326)) as lat \
-            , x(st_transform(st_centroid(the_geom),4326)) as lon \
-            , st_box2d(the_geom) as geom_st_box2d \
+            , st_y(st_transform(st_centroid(the_geom),4326)) as lat \
+            , st_x(st_transform(st_centroid(the_geom),4326)) as lon \
+            , box2d(the_geom) as geom_st_box2d \
             , fco::text as label \
             , gtdboid::text as feature_id \
         FROM public.vec200_supply
@@ -284,9 +284,9 @@ source src_ch_swisstopo_vec25-strassennetz : def_queryable_features
             , 'feature' as origin \
             , 'ch.swisstopo.vec25-strassennetz' as layer \
             , quadindex(the_geom) as geom_quadindex \
-            , y(st_transform(st_centroid(the_geom),4326)) as lat \
-            , x(st_transform(st_centroid(the_geom),4326)) as lon \
-            , st_box2d(the_geom) as geom_st_box2d \
+            , st_y(st_transform(st_centroid(the_geom),4326)) as lat \
+            , st_x(st_transform(st_centroid(the_geom),4326)) as lon \
+            , box2d(the_geom) as geom_st_box2d \
             , objectid::text as label \
             , objectid::text as feature_id \
         FROM public.v25_str_25_l_tooltip
@@ -300,9 +300,9 @@ source src_ch_swisstopo_vec25-uebrigerverkehr : def_queryable_features
             , 'feature' as origin \
             , 'ch.swisstopo.vec25-uebrigerverkehr' as layer \
             , quadindex(the_geom) as geom_quadindex \
-            , y(st_transform(st_centroid(the_geom),4326)) as lat \
-            , x(st_transform(st_centroid(the_geom),4326)) as lon \
-            , st_box2d(the_geom) as geom_st_box2d \
+            , st_y(st_transform(st_centroid(the_geom),4326)) as lat \
+            , st_x(st_transform(st_centroid(the_geom),4326)) as lon \
+            , box2d(the_geom) as geom_st_box2d \
             , coalesce(length::text,'')||' [m]' as label \
             , objectid::text as feature_id \
         FROM public.v25_uvk_25_l
@@ -316,9 +316,9 @@ source src_ch_swisstopo_vec25-anlagen : def_queryable_features
             , 'feature' as origin \
             , 'ch.swisstopo.vec25-anlagen' as layer \
             , quadindex(the_geom) as geom_quadindex \
-            , y(st_transform(st_centroid(the_geom),4326)) as lat \
-            , x(st_transform(st_centroid(the_geom),4326)) as lon \
-            , st_box2d(the_geom) as geom_st_box2d \
+            , st_y(st_transform(st_centroid(the_geom),4326)) as lat \
+            , st_x(st_transform(st_centroid(the_geom),4326)) as lon \
+            , box2d(the_geom) as geom_st_box2d \
             , coalesce(area::text,'')||' [m2]' as label \
             , objectid::text as feature_id \
         FROM public.v25_anl_25_a
@@ -332,9 +332,9 @@ source src_ch_swisstopo_vec25-eisenbahnnetz : def_queryable_features
             , 'feature' as origin \
             , 'ch.swisstopo.vec25-eisenbahnnetz' as layer \
             , quadindex(the_geom) as geom_quadindex \
-            , y(st_transform(st_centroid(the_geom),4326)) as lat \
-            , x(st_transform(st_centroid(the_geom),4326)) as lon \
-            , st_box2d(the_geom) as geom_st_box2d \
+            , st_y(st_transform(st_centroid(the_geom),4326)) as lat \
+            , st_x(st_transform(st_centroid(the_geom),4326)) as lon \
+            , box2d(the_geom) as geom_st_box2d \
             , coalesce(length::text,'')||' [m]' as label \
             , objectid::text as feature_id \
         FROM public.v25_eis_25_l
@@ -348,9 +348,9 @@ source src_ch_swisstopo_vec25-gebaeude : def_queryable_features
             , 'feature' as origin \
             , 'ch.swisstopo.vec25-gebaeude' as layer \
             , quadindex(the_geom) as geom_quadindex \
-            , y(st_transform(st_centroid(the_geom),4326)) as lat \
-            , x(st_transform(st_centroid(the_geom),4326)) as lon \
-            , st_box2d(the_geom) as geom_st_box2d \
+            , st_y(st_transform(st_centroid(the_geom),4326)) as lat \
+            , st_x(st_transform(st_centroid(the_geom),4326)) as lon \
+            , box2d(the_geom) as geom_st_box2d \
             , coalesce(area::text,'')||' [m2]' as label \
             , objectid::text as feature_id \
         FROM public.v25_geb_25_a
@@ -364,9 +364,9 @@ source src_ch_swisstopo_vec25-gewaessernetz : def_queryable_features
             , 'feature' as origin \
             , 'ch.swisstopo.vec25-gewaessernetz' as layer \
             , quadindex(the_geom) as geom_quadindex \
-            , y(st_transform(st_centroid(the_geom),4326)) as lat \
-            , x(st_transform(st_centroid(the_geom),4326)) as lon \
-            , st_box2d(the_geom) as geom_st_box2d \
+            , st_y(st_transform(st_centroid(the_geom),4326)) as lat \
+            , st_x(st_transform(st_centroid(the_geom),4326)) as lon \
+            , box2d(the_geom) as geom_st_box2d \
             , name::text as label \
             , objectid::text as feature_id \
         FROM public.v25_gwn_25_l
@@ -380,9 +380,9 @@ source src_ch_swisstopo_vec25-primaerflaechen : def_queryable_features
             , 'feature' as origin \
             , 'ch.swisstopo.vec25-primaerflaechen' as layer \
             , quadindex(the_geom) as geom_quadindex \
-            , y(st_transform(st_centroid(the_geom),4326)) as lat \
-            , x(st_transform(st_centroid(the_geom),4326)) as lon \
-            , st_box2d(the_geom) as geom_st_box2d \
+            , st_y(st_transform(st_centroid(the_geom),4326)) as lat \
+            , st_x(st_transform(st_centroid(the_geom),4326)) as lon \
+            , box2d(the_geom) as geom_st_box2d \
             , coalesce(area::text,'')||' [m2]' as label \
             , objectid::text as feature_id \
         FROM public.v25_pri25_a
@@ -396,9 +396,9 @@ source src_ch_swisstopo_vec25-einzelobjekte : def_queryable_features
             , 'feature' as origin \
             , 'ch.swisstopo.vec25-einzelobjekte' as layer \
             , quadindex(the_geom) as geom_quadindex \
-            , y(st_transform(st_centroid(the_geom),4326)) as lat \
-            , x(st_transform(st_centroid(the_geom),4326)) as lon \
-            , st_box2d(the_geom) as geom_st_box2d \
+            , st_y(st_transform(st_centroid(the_geom),4326)) as lat \
+            , st_x(st_transform(st_centroid(the_geom),4326)) as lon \
+            , box2d(the_geom) as geom_st_box2d \
             , coalesce(length::text,'')||' [m]' as label \
             , objectid::text as feature_id \
         FROM public.v25_eob_25_l
@@ -412,9 +412,9 @@ source src_ch_swisstopo_vec25-heckenbaeume : def_queryable_features
             , 'feature' as origin \
             , 'ch.swisstopo.vec25-heckenbaeume' as layer \
             , quadindex(the_geom) as geom_quadindex \
-            , y(st_transform(st_centroid(the_geom),4326)) as lat \
-            , x(st_transform(st_centroid(the_geom),4326)) as lon \
-            , st_box2d(the_geom) as geom_st_box2d \
+            , st_y(st_transform(st_centroid(the_geom),4326)) as lat \
+            , st_x(st_transform(st_centroid(the_geom),4326)) as lon \
+            , box2d(the_geom) as geom_st_box2d \
             , coalesce(length::text,'')||' [m]' as label \
             , objectid::text as feature_id \
         FROM public.v25_heb_25_l
@@ -428,9 +428,9 @@ source src_ch_swisstopo_dreiecksvermaschung : def_queryable_features
             , 'feature' as origin \
             , 'ch.swisstopo.dreiecksvermaschung' as layer \
             , quadindex(the_geom) as geom_quadindex \
-            , y(st_transform(st_centroid(the_geom),4326)) as lat \
-            , x(st_transform(st_centroid(the_geom),4326)) as lon \
-            , st_box2d(the_geom) as geom_st_box2d \
+            , st_y(st_transform(st_centroid(the_geom),4326)) as lat \
+            , st_x(st_transform(st_centroid(the_geom),4326)) as lon \
+            , box2d(the_geom) as geom_st_box2d \
             , nom::text as label \
             , bgdi_id::text as feature_id \
         FROM geodaesie.dreiecksvermaschung
@@ -444,9 +444,9 @@ source src_ch_swisstopo_geologie-spezialkarten_schweiz_metadata : def_queryable_
             , 'feature' as origin \
             , 'ch.swisstopo.geologie-spezialkarten_schweiz.metadata' as layer \
             , quadindex(the_geom) as geom_quadindex \
-            , y(st_transform(st_centroid(the_geom),4326)) as lat \
-            , x(st_transform(st_centroid(the_geom),4326)) as lon \
-            , st_box2d(the_geom) as geom_st_box2d \
+            , st_y(st_transform(st_centroid(the_geom),4326)) as lat \
+            , st_x(st_transform(st_centroid(the_geom),4326)) as lon \
+            , box2d(the_geom) as geom_st_box2d \
             , nr::text as label \
             , nr::text as feature_id \
         FROM geol.kv_gsk_all
@@ -460,9 +460,9 @@ source src_ch_swisstopo_pixelkarte-pk25_metadata : def_queryable_features
             , 'feature' as origin \
             , 'ch.swisstopo.pixelkarte-pk25.metadata' as layer \
             , quadindex(the_geom) as geom_quadindex \
-            , y(st_transform(st_centroid(the_geom),4326)) as lat \
-            , x(st_transform(st_centroid(the_geom),4326)) as lon \
-            , st_box2d(the_geom) as geom_st_box2d \
+            , st_y(st_transform(st_centroid(the_geom),4326)) as lat \
+            , st_x(st_transform(st_centroid(the_geom),4326)) as lon \
+            , box2d(the_geom) as geom_st_box2d \
             , lk_name::text as label \
             , kbnum::text as feature_id \
         FROM datenstand.view_gridstand_datenhaltung_pk25_tilecache
@@ -476,9 +476,9 @@ source src_ch_swisstopo_pixelkarte-pk50_metadata : def_queryable_features
             , 'feature' as origin \
             , 'ch.swisstopo.pixelkarte-pk50.metadata' as layer \
             , quadindex(the_geom) as geom_quadindex \
-            , y(st_transform(st_centroid(the_geom),4326)) as lat \
-            , x(st_transform(st_centroid(the_geom),4326)) as lon \
-            , st_box2d(the_geom) as geom_st_box2d \
+            , st_y(st_transform(st_centroid(the_geom),4326)) as lat \
+            , st_x(st_transform(st_centroid(the_geom),4326)) as lon \
+            , box2d(the_geom) as geom_st_box2d \
             , lk_name::text as label \
             , kbnum::text as feature_id \
         FROM datenstand.view_gridstand_datenhaltung_pk50_tilecache
@@ -492,9 +492,9 @@ source src_ch_swisstopo_pixelkarte-pk100_metadata : def_queryable_features
             , 'feature' as origin \
             , 'ch.swisstopo.pixelkarte-pk100.metadata' as layer \
             , quadindex(the_geom) as geom_quadindex \
-            , y(st_transform(st_centroid(the_geom),4326)) as lat \
-            , x(st_transform(st_centroid(the_geom),4326)) as lon \
-            , st_box2d(the_geom) as geom_st_box2d \
+            , st_y(st_transform(st_centroid(the_geom),4326)) as lat \
+            , st_x(st_transform(st_centroid(the_geom),4326)) as lon \
+            , box2d(the_geom) as geom_st_box2d \
             , lk_name::text as label \
             , kbnum::text as feature_id \
         FROM datenstand.view_gridstand_datenhaltung_pk100_tilecache
@@ -508,9 +508,9 @@ source src_ch_swisstopo_pixelkarte-pk200_metadata : def_queryable_features
             , 'feature' as origin \
             , 'ch.swisstopo.pixelkarte-pk200.metadata' as layer \
             , quadindex(the_geom) as geom_quadindex \
-            , y(st_transform(st_centroid(the_geom),4326)) as lat \
-            , x(st_transform(st_centroid(the_geom),4326)) as lon \
-            , st_box2d(the_geom) as geom_st_box2d \
+            , st_y(st_transform(st_centroid(the_geom),4326)) as lat \
+            , st_x(st_transform(st_centroid(the_geom),4326)) as lon \
+            , box2d(the_geom) as geom_st_box2d \
             , lk_name::text as label \
             , kbnum::text as feature_id \
          FROM datenstand.view_gridstand_datenhaltung_pk200_tilecache
@@ -524,9 +524,9 @@ source src_ch_swisstopo_pixelkarte-pk500_metadata : def_queryable_features
             , 'feature' as origin \
             , 'ch.swisstopo.pixelkarte-pk500.metadata' as layer \
             , quadindex(the_geom) as geom_quadindex \
-            , y(st_transform(st_centroid(the_geom),4326)) as lat \
-            , x(st_transform(st_centroid(the_geom),4326)) as lon \
-            , st_box2d(the_geom) as geom_st_box2d \
+            , st_y(st_transform(st_centroid(the_geom),4326)) as lat \
+            , st_x(st_transform(st_centroid(the_geom),4326)) as lon \
+            , box2d(the_geom) as geom_st_box2d \
             , lk_name::text as label \
             , kbnum::text as feature_id \
         FROM datenstand.view_gridstand_datenhaltung_pk500_tilecache
@@ -540,9 +540,9 @@ source src_ch_swisstopo_images-swissimage_metadata : def_queryable_features
             , 'feature' as origin \
             , 'ch.swisstopo.images-swissimage.metadata' as layer \
             , quadindex(the_geom) as geom_quadindex \
-            , y(st_transform(st_centroid(the_geom),4326)) as lat \
-            , x(st_transform(st_centroid(the_geom),4326)) as lon \
-            , st_box2d(the_geom) as geom_st_box2d \
+            , st_y(st_transform(st_centroid(the_geom),4326)) as lat \
+            , st_x(st_transform(st_centroid(the_geom),4326)) as lon \
+            , box2d(the_geom) as geom_st_box2d \
             , lk25_name::text as label \
             , tilenumber::text as feature_id \
         FROM datenstand.view_gridstand_datenhaltung_swissimage_tilecache
@@ -556,9 +556,9 @@ source src_ch_swisstopo_geologie-geocover_metadata : def_queryable_features
             , 'feature' as origin \
             , 'ch.swisstopo.geologie-geocover.metadata' as layer \
             , quadindex(the_geom) as geom_quadindex \
-            , y(st_transform(st_centroid(the_geom),4326)) as lat \
-            , x(st_transform(st_centroid(the_geom),4326)) as lon \
-            , st_box2d(the_geom) as geom_st_box2d \
+            , st_y(st_transform(st_centroid(the_geom),4326)) as lat \
+            , st_x(st_transform(st_centroid(the_geom),4326)) as lon \
+            , box2d(the_geom) as geom_st_box2d \
             , nr::text as label \
             , gid::text as feature_id \
         FROM geol.kv_geocover
@@ -572,9 +572,9 @@ source src_ch_swisstopo_geologie-geolkarten500_metadata : def_queryable_features
             , 'feature' as origin \
             , 'ch.swisstopo.geologie-geolkarten500.metadata' as layer \
             , quadindex(the_geom) as geom_quadindex \
-            , y(st_transform(st_centroid(the_geom),4326)) as lat \
-            , x(st_transform(st_centroid(the_geom),4326)) as lon \
-            , st_box2d(the_geom) as geom_st_box2d \
+            , st_y(st_transform(st_centroid(the_geom),4326)) as lat \
+            , st_x(st_transform(st_centroid(the_geom),4326)) as lon \
+            , box2d(the_geom) as geom_st_box2d \
             , bgdi_id::text as label \
             , bgdi_id::text as feature_id \
         FROM public.gk500
@@ -588,9 +588,9 @@ source src_ch_swisstopo_geologie-geologischer_atlas : def_queryable_features
             , 'feature' as origin \
             , 'ch.swisstopo.geologie-geologischer_atlas' as layer \
             , quadindex(the_geom) as geom_quadindex \
-            , y(st_transform(st_centroid(the_geom),4326)) as lat \
-            , x(st_transform(st_centroid(the_geom),4326)) as lon \
-            , st_box2d(the_geom) as geom_st_box2d \
+            , st_y(st_transform(st_centroid(the_geom),4326)) as lat \
+            , st_x(st_transform(st_centroid(the_geom),4326)) as lon \
+            , box2d(the_geom) as geom_st_box2d \
             , titel::text as label \
             , nr::text as feature_id \
         FROM geol.kv_ga25_pk
@@ -604,9 +604,9 @@ source src_ch_swisstopo_geologie-geologische_karte_1 : def_queryable_features
             , 'feature' as origin \
             , 'ch.swisstopo.geologie-geologische_karte' as layer \
             , quadindex(the_geom) as geom_quadindex \
-            , y(st_transform(st_centroid(the_geom),4326)) as lat \
-            , x(st_transform(st_centroid(the_geom),4326)) as lon \
-            , st_box2d(the_geom) as geom_st_box2d \
+            , st_y(st_transform(st_centroid(the_geom),4326)) as lat \
+            , st_x(st_transform(st_centroid(the_geom),4326)) as lon \
+            , box2d(the_geom) as geom_st_box2d \
             , type_de::text as label \
             , fid::text as feature_id \
         FROM geol.geologische_karte_line
@@ -620,9 +620,9 @@ source src_ch_swisstopo_geologie-geologische_karte_2 : def_queryable_features
             , 'feature' as origin \
             , 'ch.swisstopo.geologie-geologische_karte' as layer \
             , quadindex(the_geom) as geom_quadindex \
-            , y(st_transform(st_centroid(the_geom),4326)) as lat \
-            , x(st_transform(st_centroid(the_geom),4326)) as lon \
-            , st_box2d(the_geom) as geom_st_box2d \
+            , st_y(st_transform(st_centroid(the_geom),4326)) as lat \
+            , st_x(st_transform(st_centroid(the_geom),4326)) as lon \
+            , box2d(the_geom) as geom_st_box2d \
             , leg_geol_d::text as label \
             , id::text as feature_id \
         FROM geol.geologische_karte_plg
@@ -636,9 +636,9 @@ source src_ch_swisstopo_geologie-geotechnik-mineralische_rohstoffe200 : def_quer
             , 'feature' as origin \
             , 'ch.swisstopo.geologie-geotechnik-mineralische_rohstoffe200' as layer \
             , quadindex(the_geom) as geom_quadindex \
-            , y(st_transform(st_centroid(the_geom),4326)) as lat \
-            , x(st_transform(st_centroid(the_geom),4326)) as lon \
-            , st_box2d(the_geom) as geom_st_box2d \
+            , st_y(st_transform(st_centroid(the_geom),4326)) as lat \
+            , st_x(st_transform(st_centroid(the_geom),4326)) as lon \
+            , box2d(the_geom) as geom_st_box2d \
             , area_name::text as label \
             , bgdi_id::text as feature_id \
         FROM geol.geotechnik_mineralische_rohstoffe200
@@ -652,9 +652,9 @@ source src_ch_swisstopo_geologie-geotechnik-gk200 : def_queryable_features
             , 'feature' as origin \
             , 'ch.swisstopo.geologie-geotechnik-gk200' as layer \
             , quadindex(the_geom) as geom_quadindex \
-            , y(st_transform(st_centroid(the_geom),4326)) as lat \
-            , x(st_transform(st_centroid(the_geom),4326)) as lon \
-            , st_box2d(the_geom) as geom_st_box2d \
+            , st_y(st_transform(st_centroid(the_geom),4326)) as lat \
+            , st_x(st_transform(st_centroid(the_geom),4326)) as lon \
+            , box2d(the_geom) as geom_st_box2d \
             , file_name::text as label \
             , bgdi_id::text as feature_id \
         FROM geol.geotechnik_gk200_lgd
@@ -668,9 +668,9 @@ source src_ch_swisstopo_geologie-geotechnik-gk500-genese : def_queryable_feature
             , 'feature' as origin \
             , 'ch.swisstopo.geologie-geotechnik-gk500-genese' as layer \
             , quadindex(the_geom) as geom_quadindex \
-            , y(st_transform(st_centroid(the_geom),4326)) as lat \
-            , x(st_transform(st_centroid(the_geom),4326)) as lon \
-            , st_box2d(the_geom) as geom_st_box2d \
+            , st_y(st_transform(st_centroid(the_geom),4326)) as lat \
+            , st_x(st_transform(st_centroid(the_geom),4326)) as lon \
+            , box2d(the_geom) as geom_st_box2d \
             , genese_de::text as label \
             , bgdi_id::text as feature_id \
         FROM geol.gk500_genese
@@ -684,9 +684,9 @@ source src_ch_swisstopo_geologie-geotechnik-gk500-gesteinsklassierung : def_quer
             , 'feature' as origin \
             , 'ch.swisstopo.geologie-geotechnik-gk500-gesteinsklassierung' as layer \
             , quadindex(the_geom) as geom_quadindex \
-            , y(st_transform(st_centroid(the_geom),4326)) as lat \
-            , x(st_transform(st_centroid(the_geom),4326)) as lon \
-            , st_box2d(the_geom) as geom_st_box2d \
+            , st_y(st_transform(st_centroid(the_geom),4326)) as lat \
+            , st_x(st_transform(st_centroid(the_geom),4326)) as lon \
+            , box2d(the_geom) as geom_st_box2d \
             , gestkl_de::text as label \
             , bgdi_id::text as feature_id \
         FROM geol.gk500_gesteinsklassierung
@@ -700,9 +700,9 @@ source src_ch_swisstopo_geo-geotechnik-gk500-lith_haupt : def_queryable_features
             , 'feature' as origin \
             , 'ch.swisstopo.geologie-geotechnik-gk500-lithologie_hauptgruppen' as layer \
             , quadindex(the_geom) as geom_quadindex \
-            , y(st_transform(st_centroid(the_geom),4326)) as lat \
-            , x(st_transform(st_centroid(the_geom),4326)) as lon \
-            , st_box2d(the_geom) as geom_st_box2d \
+            , st_y(st_transform(st_centroid(the_geom),4326)) as lat \
+            , st_x(st_transform(st_centroid(the_geom),4326)) as lon \
+            , box2d(the_geom) as geom_st_box2d \
             , bgdi_tooltip_de::text as label \
             , bgdi_id::text as feature_id \
         FROM geol.gk500_lithologie_hauptgruppen
@@ -716,9 +716,9 @@ source src_ch_swisstopo_geologie-geotechnik-steinbrueche_1980 : def_queryable_fe
             , 'feature' as origin \
             , 'ch.swisstopo.geologie-geotechnik-steinbrueche_1980' as layer \
             , quadindex(the_geom) as geom_quadindex \
-            , y(st_transform(st_centroid(the_geom),4326)) as lat \
-            , x(st_transform(st_centroid(the_geom),4326)) as lon \
-            , st_box2d(the_geom) as geom_st_box2d \
+            , st_y(st_transform(st_centroid(the_geom),4326)) as lat \
+            , st_x(st_transform(st_centroid(the_geom),4326)) as lon \
+            , box2d(the_geom) as geom_st_box2d \
             , gesteinsgr::text as label \
             , id::text as feature_id \
         FROM geol.geotechnik_steinbrueche_1980
@@ -732,9 +732,9 @@ source src_ch_swisstopo_geologie-geotechnik-steinbrueche_1995 : def_queryable_fe
             , 'feature' as origin \
             , 'ch.swisstopo.geologie-geotechnik-steinbrueche_1995' as layer \
             , quadindex(the_geom) as geom_quadindex \
-            , y(st_transform(st_centroid(the_geom),4326)) as lat \
-            , x(st_transform(st_centroid(the_geom),4326)) as lon \
-            , st_box2d(the_geom) as geom_st_box2d \
+            , st_y(st_transform(st_centroid(the_geom),4326)) as lat \
+            , st_x(st_transform(st_centroid(the_geom),4326)) as lon \
+            , box2d(the_geom) as geom_st_box2d \
             , gesteinsgr::text as label \
             , id::text as feature_id \
         FROM geol.geotechnik_steinbrueche_1995
@@ -748,9 +748,9 @@ source src_ch_swisstopo_geologie-geotechnik-zementindustrie_1965 : def_queryable
             , 'feature' as origin \
             , 'ch.swisstopo.geologie-geotechnik-zementindustrie_1965' as layer \
             , quadindex(the_geom) as geom_quadindex \
-            , y(st_transform(st_centroid(the_geom),4326)) as lat \
-            , x(st_transform(st_centroid(the_geom),4326)) as lon \
-            , st_box2d(the_geom) as geom_st_box2d \
+            , st_y(st_transform(st_centroid(the_geom),4326)) as lat \
+            , st_x(st_transform(st_centroid(the_geom),4326)) as lon \
+            , box2d(the_geom) as geom_st_box2d \
             , stoff::text as label \
             , id::text as feature_id \
         FROM geol.geotechnik_zementindustrie
@@ -764,9 +764,9 @@ source src_ch_swisstopo_geologie-geotechnik-zementindustrie_1995 : def_queryable
             , 'feature' as origin \
             , 'ch.swisstopo.geologie-geotechnik-zementindustrie_1995' as layer \
             , quadindex(the_geom) as geom_quadindex \
-            , y(st_transform(st_centroid(the_geom),4326)) as lat \
-            , x(st_transform(st_centroid(the_geom),4326)) as lon \
-            , st_box2d(the_geom) as geom_st_box2d \
+            , st_y(st_transform(st_centroid(the_geom),4326)) as lat \
+            , st_x(st_transform(st_centroid(the_geom),4326)) as lon \
+            , box2d(the_geom) as geom_st_box2d \
             , stoff::text as label \
             , id::text as feature_id \
         FROM geol.geotechnik_zementindustrie
@@ -780,9 +780,9 @@ source src_ch_swisstopo_geologie-hydrogeol_karte-grundwasservor : def_queryable_
             , 'feature' as origin \
             , 'ch.swisstopo.geologie-hydrogeologische_karte-grundwasservorkommen' as layer \
             , quadindex(the_geom) as geom_quadindex \
-            , y(st_transform(st_centroid(the_geom),4326)) as lat \
-            , x(st_transform(st_centroid(the_geom),4326)) as lon \
-            , st_box2d(the_geom) as geom_st_box2d \
+            , st_y(st_transform(st_centroid(the_geom),4326)) as lat \
+            , st_x(st_transform(st_centroid(the_geom),4326)) as lon \
+            , box2d(the_geom) as geom_st_box2d \
             , type_de::text as label \
             , bgdi_id::text as feature_id \
         FROM geol.grundwasservorkommen
@@ -796,9 +796,9 @@ source src_ch_swisstopo_geologie-hydrogeol_karte-grundwasservul : def_queryable_
             , 'feature' as origin \
             , 'ch.swisstopo.geologie-hydrogeologische_karte-grundwasservulnerabilitaet' as layer \
             , quadindex(the_geom) as geom_quadindex \
-            , y(st_transform(st_centroid(the_geom),4326)) as lat \
-            , x(st_transform(st_centroid(the_geom),4326)) as lon \
-            , st_box2d(the_geom) as geom_st_box2d \
+            , st_y(st_transform(st_centroid(the_geom),4326)) as lat \
+            , st_x(st_transform(st_centroid(the_geom),4326)) as lon \
+            , box2d(the_geom) as geom_st_box2d \
             , type_de::text as label \
             , bgdi_id::text as feature_id \
     FROM geol.grundwasservorkommen_plg
@@ -812,9 +812,9 @@ source src_ch_swisstopo_geologie-geophysik-geothermie : def_queryable_features
             , 'feature' as origin \
             , 'ch.swisstopo.geologie-geophysik-geothermie' as layer \
             , quadindex(the_geom) as geom_quadindex \
-            , y(st_transform(st_centroid(the_geom),4326)) as lat \
-            , x(st_transform(st_centroid(the_geom),4326)) as lon \
-            , st_box2d(the_geom) as geom_st_box2d \
+            , st_y(st_transform(st_centroid(the_geom),4326)) as lat \
+            , st_x(st_transform(st_centroid(the_geom),4326)) as lon \
+            , box2d(the_geom) as geom_st_box2d \
             , contour::text as label \
             , gid::text as feature_id \
         FROM geol.geophysik_geothermie
@@ -828,9 +828,9 @@ source src_ch_swisstopo_geologie-geophysik-deklination : def_queryable_features
             , 'feature' as origin \
             , 'ch.swisstopo.geologie-geophysik-deklination' as layer \
             , quadindex(the_geom) as geom_quadindex \
-            , y(st_transform(st_centroid(the_geom),4326)) as lat \
-            , x(st_transform(st_centroid(the_geom),4326)) as lon \
-            , st_box2d(the_geom) as geom_st_box2d \
+            , st_y(st_transform(st_centroid(the_geom),4326)) as lat \
+            , st_x(st_transform(st_centroid(the_geom),4326)) as lon \
+            , box2d(the_geom) as geom_st_box2d \
             , magne::text as label \
             , gid::text as feature_id \
         FROM geol.geophysik_deklination
@@ -844,9 +844,9 @@ source src_ch_swisstopo_geologie-geophysik-inklination : def_queryable_features
             , 'feature' as origin \
             , 'ch.swisstopo.geologie-geophysik-inklination' as layer \
             , quadindex(the_geom) as geom_quadindex \
-            , y(st_transform(st_centroid(the_geom),4326)) as lat \
-            , x(st_transform(st_centroid(the_geom),4326)) as lon \
-            , st_box2d(the_geom) as geom_st_box2d \
+            , st_y(st_transform(st_centroid(the_geom),4326)) as lat \
+            , st_x(st_transform(st_centroid(the_geom),4326)) as lon \
+            , box2d(the_geom) as geom_st_box2d \
             , contour::text as label \
             , gid::text as feature_id \
         FROM geol.geophysik_inklination
@@ -860,9 +860,9 @@ source src_ch_swisstopo_geologie-geophysik-aeromagnetische_karte_jura : def_quer
             , 'feature' as origin \
             , 'ch.swisstopo.geologie-geophysik-aeromagnetische_karte_jura' as layer \
             , quadindex(the_geom) as geom_quadindex \
-            , y(st_transform(st_centroid(the_geom),4326)) as lat \
-            , x(st_transform(st_centroid(the_geom),4326)) as lon \
-            , st_box2d(the_geom) as geom_st_box2d \
+            , st_y(st_transform(st_centroid(the_geom),4326)) as lat \
+            , st_x(st_transform(st_centroid(the_geom),4326)) as lon \
+            , box2d(the_geom) as geom_st_box2d \
             , et_fromatt::text as label \
             , gid::text as feature_id \
         FROM geol.gravimetrie_aeromagnetik_jura
@@ -876,9 +876,9 @@ source src_ch_swisstopo_geologie-geodaesie-isostatische_anomalien : def_queryabl
             , 'feature' as origin \
             , 'ch.swisstopo.geologie-geodaesie-isostatische_anomalien' as layer \
             , quadindex(the_geom) as geom_quadindex \
-            , y(st_transform(st_centroid(the_geom),4326)) as lat \
-            , x(st_transform(st_centroid(the_geom),4326)) as lon \
-            , st_box2d(the_geom) as geom_st_box2d \
+            , st_y(st_transform(st_centroid(the_geom),4326)) as lat \
+            , st_x(st_transform(st_centroid(the_geom),4326)) as lon \
+            , box2d(the_geom) as geom_st_box2d \
             , et_fromatt::text as label \
             , gid::text as feature_id \
         FROM geol.schwerekarte_isostatische_anomalien
@@ -892,9 +892,9 @@ source src_ch_swisstopo_geologie-geodaesie-bouguer_anomalien : def_queryable_fea
             , 'feature' as origin \
             , 'ch.swisstopo.geologie-geodaesie-bouguer_anomalien' as layer \
             , quadindex(the_geom) as geom_quadindex \
-            , y(st_transform(st_centroid(the_geom),4326)) as lat \
-            , x(st_transform(st_centroid(the_geom),4326)) as lon \
-            , st_box2d(the_geom) as geom_st_box2d \
+            , st_y(st_transform(st_centroid(the_geom),4326)) as lat \
+            , st_x(st_transform(st_centroid(the_geom),4326)) as lon \
+            , box2d(the_geom) as geom_st_box2d \
             , et_fromatt::text as label \
             , gid::text as feature_id \
         FROM geol.geodaesie_bouguer_anomalien
@@ -908,9 +908,9 @@ source src_ch_swisstopo_geologie-geophysik-totalintensitaet : def_queryable_feat
             , 'feature' as origin \
             , 'ch.swisstopo.geologie-geophysik-totalintensitaet' as layer \
             , quadindex(the_geom) as geom_quadindex \
-            , y(st_transform(st_centroid(the_geom),4326)) as lat \
-            , x(st_transform(st_centroid(the_geom),4326)) as lon \
-            , st_box2d(the_geom) as geom_st_box2d \
+            , st_y(st_transform(st_centroid(the_geom),4326)) as lat \
+            , st_x(st_transform(st_centroid(the_geom),4326)) as lon \
+            , box2d(the_geom) as geom_st_box2d \
             , contour::text as label \
             , gid::text as feature_id \
         FROM geol.geophysik_totalintensitaet
@@ -924,9 +924,9 @@ source src_ch_swisstopo_geologie-tektonische_karte_1 : def_queryable_features
             , 'feature' as origin \
             , 'ch.swisstopo.geologie-tektonische_karte' as layer \
             , quadindex(the_geom) as geom_quadindex \
-            , y(st_transform(st_centroid(the_geom),4326)) as lat \
-            , x(st_transform(st_centroid(the_geom),4326)) as lon \
-            , st_box2d(the_geom) as geom_st_box2d \
+            , st_y(st_transform(st_centroid(the_geom),4326)) as lat \
+            , st_x(st_transform(st_centroid(the_geom),4326)) as lon \
+            , box2d(the_geom) as geom_st_box2d \
             , type_de::text as label \
             , fid::text as feature_id \
         FROM geol.tektonische_karte_line
@@ -940,9 +940,9 @@ source src_ch_swisstopo_geologie-tektonische_karte_2 : def_queryable_features
             , 'feature' as origin \
             , 'ch.swisstopo.geologie-tektonische_karte' as layer \
             , quadindex(the_geom) as geom_quadindex \
-            , y(st_transform(st_centroid(the_geom),4326)) as lat \
-            , x(st_transform(st_centroid(the_geom),4326)) as lon \
-            , st_box2d(the_geom) as geom_st_box2d \
+            , st_y(st_transform(st_centroid(the_geom),4326)) as lat \
+            , st_x(st_transform(st_centroid(the_geom),4326)) as lon \
+            , box2d(the_geom) as geom_st_box2d \
             , type_de::text as label \
             , fid::text as feature_id \
         FROM geol.tektonische_karte_flaechen
@@ -956,9 +956,9 @@ source src_ch_swisstopo_swisstlm3d-wanderwege : def_queryable_features
             , 'feature' as origin \
             , 'ch.swisstopo.swisstlm3d-wanderwege' as layer \
             , quadindex(the_geom) as geom_quadindex \
-            , y(st_transform(st_centroid(the_geom),4326)) as lat \
-            , x(st_transform(st_centroid(the_geom),4326)) as lon \
-            , st_box2d(the_geom) as geom_st_box2d \
+            , st_y(st_transform(st_centroid(the_geom),4326)) as lat \
+            , st_x(st_transform(st_centroid(the_geom),4326)) as lon \
+            , box2d(the_geom) as geom_st_box2d \
             , nr::text as label \
             , nr as feature_id \
         FROM karto.wanderwege_swissmap
@@ -973,9 +973,9 @@ source src_ch_swisstopo-vd_geometa-standav : def_queryable_features
             , 'feature' as origin \
             , 'ch.swisstopo-vd.geometa-standav' as layer \
             , quadindex(the_geom) as geom_quadindex \
-            , y(st_transform(st_centroid(the_geom),4326)) as lat \
-            , x(st_transform(st_centroid(the_geom),4326)) as lon \
-            , st_box2d(the_geom) as geom_st_box2d \
+            , st_y(st_transform(st_centroid(the_geom),4326)) as lat \
+            , st_x(st_transform(st_centroid(the_geom),4326)) as lon \
+            , box2d(the_geom) as geom_st_box2d \
             , frame::text as label \
             , gid::text as feature_id \
         FROM vd.amogr_standav
@@ -989,9 +989,9 @@ source src_ch_swisstopo-vd_geometa-los : def_queryable_features
             , 'feature' as origin \
             , 'ch.swisstopo-vd.geometa-los' as layer \
             , quadindex(the_geom) as geom_quadindex \
-            , y(st_transform(st_centroid(the_geom),4326)) as lat \
-            , x(st_transform(st_centroid(the_geom),4326)) as lon \
-            , st_box2d(the_geom) as geom_st_box2d \
+            , st_y(st_transform(st_centroid(the_geom),4326)) as lat \
+            , st_x(st_transform(st_centroid(the_geom),4326)) as lon \
+            , box2d(the_geom) as geom_st_box2d \
             , operatsname::text as label \
             , gid::text as feature_id \
         FROM vd.amogr_los
@@ -1005,9 +1005,9 @@ source src_ch_swisstopo-vd_geometa-gemeinde : def_queryable_features
             , 'feature' as origin \
             , 'ch.swisstopo-vd.geometa-gemeinde' as layer \
             , quadindex(the_geom) as geom_quadindex \
-            , y(st_transform(st_centroid(the_geom),4326)) as lat \
-            , x(st_transform(st_centroid(the_geom),4326)) as lon \
-            , st_box2d(the_geom) as geom_st_box2d \
+            , st_y(st_transform(st_centroid(the_geom),4326)) as lat \
+            , st_x(st_transform(st_centroid(the_geom),4326)) as lon \
+            , box2d(the_geom) as geom_st_box2d \
             , gemeindename::text as label \
             , gid::text as feature_id \
         FROM vd.amogr_gemeinde
@@ -1021,9 +1021,9 @@ source src_ch_swisstopo-vd_geometa-grundbuch : def_queryable_features
             , 'feature' as origin \
             , 'ch.swisstopo-vd.geometa-grundbuch' as layer \
             , quadindex(the_geom) as geom_quadindex \
-            , y(st_transform(st_centroid(the_geom),4326)) as lat \
-            , x(st_transform(st_centroid(the_geom),4326)) as lon \
-            , st_box2d(the_geom) as geom_st_box2d \
+            , st_y(st_transform(st_centroid(the_geom),4326)) as lat \
+            , st_x(st_transform(st_centroid(the_geom),4326)) as lon \
+            , box2d(the_geom) as geom_st_box2d \
             , ortsteil_grundbuch::text as label \
             , gid::text as feature_id \
         FROM vd.amogr_grundbuch
@@ -1037,9 +1037,9 @@ source src_ch_swisstopo-vd_geometa-nfgeom : def_queryable_features
             , 'feature' as origin \
             , 'ch.swisstopo-vd.geometa-nfgeom' as layer \
             , quadindex(the_geom) as geom_quadindex \
-            , y(st_transform(st_centroid(the_geom),4326)) as lat \
-            , x(st_transform(st_centroid(the_geom),4326)) as lon \
-            , st_box2d(the_geom) as geom_st_box2d \
+            , st_y(st_transform(st_centroid(the_geom),4326)) as lat \
+            , st_x(st_transform(st_centroid(the_geom),4326)) as lon \
+            , box2d(the_geom) as geom_st_box2d \
             , name::text as label \
             , gid::text as feature_id \
         FROM vd.amogr_nfgeom
@@ -1053,9 +1053,9 @@ source src_ch_swisstopo-vd_stand-oerebkataster : def_queryable_features
             , 'feature' as origin \
             , 'ch.swisstopo-vd.stnad-oerebkataster' as layer \
             , quadindex(the_geom) as geom_quadindex \
-            , y(st_transform(st_centroid(the_geom),4326)) as lat \
-            , x(st_transform(st_centroid(the_geom),4326)) as lon \
-            , st_box2d(the_geom) as geom_st_box2d \
+            , st_y(st_transform(st_centroid(the_geom),4326)) as lat \
+            , st_x(st_transform(st_centroid(the_geom),4326)) as lon \
+            , box2d(the_geom) as geom_st_box2d \
             , gemeindename::text as label \
             , gid::text as feature_id \
         FROM vd.view_oereb_nfgeom
@@ -1069,9 +1069,9 @@ source src_ch_swisstopo_transformationsgenauigkeit : def_queryable_features
             , 'feature' as origin \
             , 'ch.swisstopo.transformationsgenauigkeit' as layer \
             , quadindex(the_geom) as geom_quadindex \
-            , y(st_transform(st_centroid(the_geom),4326)) as lat \
-            , x(st_transform(st_centroid(the_geom),4326)) as lon \
-            , st_box2d(the_geom) as geom_st_box2d \
+            , st_y(st_transform(st_centroid(the_geom),4326)) as lat \
+            , st_x(st_transform(st_centroid(the_geom),4326)) as lon \
+            , box2d(the_geom) as geom_st_box2d \
             , sg_name::text as label \
             , identifier::text as feature_id \
         FROM vd.spannungsarme_gebiete
@@ -1085,9 +1085,9 @@ source src_ch_swisstopo-vd_spannungsarme-gebiete : def_queryable_features
             , 'feature' as origin \
             , 'ch.swisstopo-vd.spannungsarme-gebiete' as layer \
             , quadindex(the_geom) as geom_quadindex \
-            , y(st_transform(st_centroid(the_geom),4326)) as lat \
-            , x(st_transform(st_centroid(the_geom),4326)) as lon \
-            , st_box2d(the_geom) as geom_st_box2d \
+            , st_y(st_transform(st_centroid(the_geom),4326)) as lat \
+            , st_x(st_transform(st_centroid(the_geom),4326)) as lon \
+            , box2d(the_geom) as geom_st_box2d \
             , sg_name::text as label \
             , identifier::text as feature_id \
         FROM vd.spannungsarme_gebiete
@@ -1101,9 +1101,9 @@ source src_ch_swisstopo_geologie-geotope_1 : def_queryable_features
             , 'feature' as origin \
             , 'ch.swisstopo.geologie-geotope' as layer \
             , quadindex(the_geom) as geom_quadindex \
-            , y(st_transform(st_centroid(the_geom),4326)) as lat \
-            , x(st_transform(st_centroid(the_geom),4326)) as lon \
-            , st_box2d(the_geom) as geom_st_box2d \
+            , st_y(st_transform(st_centroid(the_geom),4326)) as lat \
+            , st_x(st_transform(st_centroid(the_geom),4326)) as lon \
+            , box2d(the_geom) as geom_st_box2d \
             , nom::text as label \
             , objectid::text as feature_id \
         FROM geol.geotope_pkt
@@ -1117,9 +1117,9 @@ source src_ch_swisstopo_geologie-geotope_2 : def_queryable_features
             , 'feature' as origin \
             , 'ch.swisstopo.geologie-geotope' as layer \
             , quadindex(the_geom) as geom_quadindex \
-            , y(st_transform(st_centroid(the_geom),4326)) as lat \
-            , x(st_transform(st_centroid(the_geom),4326)) as lon \
-            , st_box2d(the_geom) as geom_st_box2d \
+            , st_y(st_transform(st_centroid(the_geom),4326)) as lat \
+            , st_x(st_transform(st_centroid(the_geom),4326)) as lon \
+            , box2d(the_geom) as geom_st_box2d \
             , nom::text as label \
             , objectid::text as feature_id \
         FROM geol.geotope_plg
@@ -1133,9 +1133,9 @@ source src_ch_swiss_geologie-geotechnik-steine_historische_bauwerke : def_querya
             , 'feature' as origin \
             , 'ch.swisstopo.geologie-geotechnik-steine_historische_bauwerke' as layer \
             , quadindex(the_geom) as geom_quadindex \
-            , y(st_transform(st_centroid(the_geom),4326)) as lat \
-            , x(st_transform(st_centroid(the_geom),4326)) as lon \
-            , st_box2d(the_geom) as geom_st_box2d \
+            , st_y(st_transform(st_centroid(the_geom),4326)) as lat \
+            , st_x(st_transform(st_centroid(the_geom),4326)) as lon \
+            , box2d(the_geom) as geom_st_box2d \
             , objekt::text as label \
             , bgdi_id::text as feature_id \
         FROM geol.geotechnik_steine_historische_bauwerke
@@ -1149,9 +1149,9 @@ source src_ch_swisstopo_geologie-generalkarte-ggk200 : def_queryable_features
             , 'feature' as origin \
             , 'ch.swisstopo.geologie-generalkarte-ggk200' as layer \
             , quadindex(the_geom) as geom_quadindex \
-            , y(st_transform(st_centroid(the_geom),4326)) as lat \
-            , x(st_transform(st_centroid(the_geom),4326)) as lon \
-            , st_box2d(the_geom) as geom_st_box2d \
+            , st_y(st_transform(st_centroid(the_geom),4326)) as lat \
+            , st_x(st_transform(st_centroid(the_geom),4326)) as lon \
+            , box2d(the_geom) as geom_st_box2d \
             , titel::text as label \
             , gid::text as feature_id \
         FROM geol.kv_ggk_pk
@@ -1165,9 +1165,9 @@ source src_ch_swisstopo_geologie-geocover_point_hydro : def_queryable_features
             , 'feature' as origin \
             , 'ch.swisstopo.geologie-geocover' as layer \
             , bgdi_quadindex as geom_quadindex \
-            , y(st_transform(st_centroid(the_geom),4326)) as lat \
-            , x(st_transform(st_centroid(the_geom),4326)) as lon \
-            , st_box2d(the_geom)::text as geom_st_box2d \
+            , st_y(st_transform(st_centroid(the_geom),4326)) as lat \
+            , st_x(st_transform(st_centroid(the_geom),4326)) as lon \
+            , box2d(the_geom)::text as geom_st_box2d \
             , description::text as label \
             , bgdi_id::text as feature_id \
         FROM geol.geocover_point_hydro
@@ -1181,9 +1181,9 @@ source src_ch_swisstopo_geologie-geocover_point_geol : def_queryable_features
             , 'feature' as origin \
             , 'ch.swisstopo.geologie-geocover' as layer \
             , bgdi_quadindex as geom_quadindex \
-            , y(st_transform(st_centroid(the_geom),4326)) as lat \
-            , x(st_transform(st_centroid(the_geom),4326)) as lon \
-            , st_box2d(the_geom)::text as geom_st_box2d \
+            , st_y(st_transform(st_centroid(the_geom),4326)) as lat \
+            , st_x(st_transform(st_centroid(the_geom),4326)) as lon \
+            , box2d(the_geom)::text as geom_st_box2d \
             , description::text as label \
             , bgdi_id::text as feature_id \
         FROM geol.geocover_point_geol
@@ -1197,9 +1197,9 @@ source src_ch_swisstopo_geologie-geocover_point_drill : def_queryable_features
             , 'feature' as origin \
             , 'ch.swisstopo.geologie-geocover' as layer \
             , bgdi_quadindex as geom_quadindex \
-            , y(st_transform(st_centroid(the_geom),4326)) as lat \
-            , x(st_transform(st_centroid(the_geom),4326)) as lon \
-            , st_box2d(the_geom)::text as geom_st_box2d \
+            , st_y(st_transform(st_centroid(the_geom),4326)) as lat \
+            , st_x(st_transform(st_centroid(the_geom),4326)) as lon \
+            , box2d(the_geom)::text as geom_st_box2d \
             , description::text as label \
             , bgdi_id::text as feature_id \
         FROM geol.geocover_point_drill
@@ -1213,9 +1213,9 @@ source src_ch_swisstopo_geologie-geocover_point_info : def_queryable_features
             , 'feature' as origin \
             , 'ch.swisstopo.geologie-geocover' as layer \
             , bgdi_quadindex as geom_quadindex \
-            , y(st_transform(st_centroid(the_geom),4326)) as lat \
-            , x(st_transform(st_centroid(the_geom),4326)) as lon \
-            , st_box2d(the_geom)::text as geom_st_box2d \
+            , st_y(st_transform(st_centroid(the_geom),4326)) as lat \
+            , st_x(st_transform(st_centroid(the_geom),4326)) as lon \
+            , box2d(the_geom)::text as geom_st_box2d \
             , description::text as label \
             , bgdi_id::text as feature_id \
         FROM geol.geocover_point_info
@@ -1229,9 +1229,9 @@ source src_ch_swisstopo_geologie-geocover_point_struct : def_queryable_features
             , 'feature' as origin \
             , 'ch.swisstopo.geologie-geocover' as layer \
             , bgdi_quadindex as geom_quadindex \
-            , y(st_transform(st_centroid(the_geom),4326)) as lat \
-            , x(st_transform(st_centroid(the_geom),4326)) as lon \
-            , st_box2d(the_geom)::text as geom_st_box2d \
+            , st_y(st_transform(st_centroid(the_geom),4326)) as lat \
+            , st_x(st_transform(st_centroid(the_geom),4326)) as lon \
+            , box2d(the_geom)::text as geom_st_box2d \
             , description::text as label \
             , bgdi_id::text as feature_id \
         FROM geol.geocover_point_struct
@@ -1245,9 +1245,9 @@ source src_ch_swisstopo_geologie-geocover_line_aux : def_queryable_features
             , 'feature' as origin \
             , 'ch.swisstopo.geologie-geocover' as layer \
             , bgdi_quadindex as geom_quadindex \
-            , y(st_transform(st_centroid(the_geom),4326)) as lat \
-            , x(st_transform(st_centroid(the_geom),4326)) as lon \
-            , st_box2d(the_geom)::text as geom_st_box2d \
+            , st_y(st_transform(st_centroid(the_geom),4326)) as lat \
+            , st_x(st_transform(st_centroid(the_geom),4326)) as lon \
+            , box2d(the_geom)::text as geom_st_box2d \
             , description::text as label \
             , bgdi_id::text as feature_id \
         FROM geol.geocover_line_aux
@@ -1261,9 +1261,9 @@ source src_ch_swisstopo_geologie-geocover_polygon_aux_1 : def_queryable_features
             , 'feature' as origin \
             , 'ch.swisstopo.geologie-geocover' as layer \
             , bgdi_quadindex as geom_quadindex \
-            , y(st_transform(st_centroid(the_geom),4326)) as lat \
-            , x(st_transform(st_centroid(the_geom),4326)) as lon \
-            , st_box2d(the_geom)::text as geom_st_box2d \
+            , st_y(st_transform(st_centroid(the_geom),4326)) as lat \
+            , st_x(st_transform(st_centroid(the_geom),4326)) as lon \
+            , box2d(the_geom)::text as geom_st_box2d \
             , description::text as label \
             , bgdi_id::text as feature_id \
         FROM geol.geocover_polygon_aux_1
@@ -1277,9 +1277,9 @@ source src_ch_swisstopo_geologie-geocover_polygon_aux_2 : def_queryable_features
             , 'feature' as origin \
             , 'ch.swisstopo.geologie-geocover' as layer \
             , bgdi_quadindex as geom_quadindex \
-            , y(st_transform(st_centroid(the_geom),4326)) as lat \
-            , x(st_transform(st_centroid(the_geom),4326)) as lon \
-            , st_box2d(the_geom)::text as geom_st_box2d \
+            , st_y(st_transform(st_centroid(the_geom),4326)) as lat \
+            , st_x(st_transform(st_centroid(the_geom),4326)) as lon \
+            , box2d(the_geom)::text as geom_st_box2d \
             , description::text as label \
             , bgdi_id::text as feature_id \
         FROM geol.geocover_polygon_aux_2
@@ -1293,9 +1293,9 @@ source src_ch_swisstopo_geologie-geocover_polygon_main : def_queryable_features
             , 'feature' as origin \
             , 'ch.swisstopo.geologie-geocover' as layer \
             , bgdi_quadindex as geom_quadindex \
-            , y(st_transform(st_centroid(the_geom),4326)) as lat \
-            , x(st_transform(st_centroid(the_geom),4326)) as lon \
-            , st_box2d(the_geom)::text as geom_st_box2d \
+            , st_y(st_transform(st_centroid(the_geom),4326)) as lat \
+            , st_x(st_transform(st_centroid(the_geom),4326)) as lon \
+            , box2d(the_geom)::text as geom_st_box2d \
             , description::text as label \
             , bgdi_id::text as feature_id \
         FROM geol.geocover_polygon_main
@@ -1345,9 +1345,9 @@ source src_ch_swisstopo_swissboundaries3d-bezirk-flaeche_fill : def_searchable_f
             , remove_accents(name) as detail \
             , 'ch.swisstopo.swissboundaries3d-bezirk-flaeche.fill' as layer \
             , quadindex(the_geom) as geom_quadindex \
-            , y(st_transform(ST_PointOnSurface(the_geom),4326)) as lat \
-            , x(st_transform(ST_PointOnSurface(the_geom),4326)) as lon \
-            , st_box2d(the_geom) as geom_st_box2d \
+            , st_y(st_transform(ST_PointOnSurface(the_geom),4326)) as lat \
+            , st_x(st_transform(ST_PointOnSurface(the_geom),4326)) as lon \
+            , box2d(the_geom) as geom_st_box2d \
             , name::text as label \
             , id::text as feature_id \
         FROM tlm.swissboundaries_bezirke
@@ -1362,9 +1362,9 @@ source src_ch_swisstopo_swissboundaries3d-gemeinde-flaeche_fill : def_searchable
             , remove_accents(gemname||' '||id::text) as detail \
             , 'ch.swisstopo.swissboundaries3d-gemeinde-flaeche.fill' as layer \
             , quadindex(the_geom) as geom_quadindex \
-            , y(st_transform(ST_PointOnSurface(the_geom),4326)) as lat \
-            , x(st_transform(ST_PointOnSurface(the_geom),4326)) as lon \
-            , st_box2d(the_geom) as geom_st_box2d \
+            , st_y(st_transform(ST_PointOnSurface(the_geom),4326)) as lat \
+            , st_x(st_transform(ST_PointOnSurface(the_geom),4326)) as lon \
+            , box2d(the_geom) as geom_st_box2d \
             , gemname::text as label \
             , id::text as feature_id \
         FROM tlm.swissboundaries_gemeinden
@@ -1379,9 +1379,9 @@ source src_ch_swisstopo_swissboundaries3d-kanton-flaeche_fill : def_searchable_f
             , remove_accents(name||' '||kantonsnr::text) as detail \
             , 'ch.swisstopo.swissboundaries3d-kanton-flaeche.fill' as layer \
             , quadindex(the_geom) as geom_quadindex \
-            , y(st_transform(ST_PointOnSurface(the_geom),4326)) as lat \
-            , x(st_transform(ST_PointOnSurface(the_geom),4326)) as lon \
-            , st_box2d(the_geom) as geom_st_box2d \
+            , st_y(st_transform(ST_PointOnSurface(the_geom),4326)) as lat \
+            , st_x(st_transform(ST_PointOnSurface(the_geom),4326)) as lon \
+            , box2d(the_geom) as geom_st_box2d \
             , name::text as label \
             , kantonsnr::text as feature_id \
         FROM tlm.swissboundaries_kantone
@@ -1396,9 +1396,9 @@ source src_ch_swisstopo-vd_ortschaftenverzeichnis_plz : def_searchable_features
             , remove_accents(plz::text||' '||langtext) as detail \
             , 'ch.swisstopo-vd.ortschaftenverzeichnis_plz' as layer \
             , quadindex(the_geom) as geom_quadindex \
-            , y(st_transform(ST_PointOnSurface(the_geom),4326)) as lat \
-            , x(st_transform(ST_PointOnSurface(the_geom),4326)) as lon \
-            , st_box2d(the_geom) as geom_st_box2d \
+            , st_y(st_transform(ST_PointOnSurface(the_geom),4326)) as lat \
+            , st_x(st_transform(ST_PointOnSurface(the_geom),4326)) as lon \
+            , box2d(the_geom) as geom_st_box2d \
             , plz::text as label \
             , os_uuid::text as feature_id \
         FROM vd.gabmo_plz
@@ -1413,9 +1413,9 @@ source src_ch_swisstopo_vec200-names-namedlocation : def_searchable_features
             , remove_accents(coalesce(objname1,'')) as detail \
             , 'ch.swisstopo.vec200-names-namedlocation' as layer \
             , quadindex(the_geom) as geom_quadindex \
-            , y(st_transform(st_centroid(the_geom),4326)) as lat \
-            , x(st_transform(st_centroid(the_geom),4326)) as lon \
-            , st_box2d(the_geom) as geom_st_box2d \
+            , st_y(st_transform(st_centroid(the_geom),4326)) as lat \
+            , st_x(st_transform(st_centroid(the_geom),4326)) as lon \
+            , box2d(the_geom) as geom_st_box2d \
             , coalesce(objname1,'')||' '||coalesce(objname2,'') as label \
             , gtdboid::text as feature_id \
         FROM public.vec200_namedlocation
@@ -1431,9 +1431,9 @@ source src_ch_swisstopo_geologie-gravimetrischer_atlas_metadata : def_searchable
             , remove_accents(nr ||' '||titel) as detail \
             , 'ch.swisstopo.geologie-gravimetrischer_atlas.metadata' as layer \
             , quadindex(the_geom) as geom_quadindex \
-            , y(st_transform(ST_PointOnSurface(the_geom),4326)) as lat \
-            , x(st_transform(ST_PointOnSurface(the_geom),4326)) as lon \
-            , st_box2d(the_geom) as geom_st_box2d \
+            , st_y(st_transform(ST_PointOnSurface(the_geom),4326)) as lat \
+            , st_x(st_transform(ST_PointOnSurface(the_geom),4326)) as lon \
+            , box2d(the_geom) as geom_st_box2d \
             , nr as feature_id \
         FROM geol.gravimetrie_atlas_metadata
 }
@@ -1448,9 +1448,9 @@ source src_ch_swisstopo_geologie-rohstoffe-industrieminerale : def_searchable_fe
             , remove_accents(name_ads) as detail \
             , 'ch.swisstopo.geologie-rohstoffe-industrieminerale' as layer \
             , quadindex(the_geom) as geom_quadindex \
-            , y(st_transform(st_centroid(the_geom),4326)) as lat \
-            , x(st_transform(st_centroid(the_geom),4326)) as lon \
-            , st_box2d(the_geom) as geom_st_box2d \
+            , st_y(st_transform(st_centroid(the_geom),4326)) as lat \
+            , st_x(st_transform(st_centroid(the_geom),4326)) as lon \
+            , box2d(the_geom) as geom_st_box2d \
             , id::text as feature_id \
         from geol.rohstoffe_industrieminerale
 }
@@ -1465,9 +1465,9 @@ source src_ch_swisstopo_geologie-rohstoffe-kohlen_bitumen_erdgas : def_searchabl
             , remove_accents(name_ads) as detail \
             , 'ch.swisstopo.geologie-rohstoffe-kohlen_bitumen_erdgas' as layer \
             , quadindex(the_geom) as geom_quadindex \
-            , y(st_transform(st_centroid(the_geom),4326)) as lat \
-            , x(st_transform(st_centroid(the_geom),4326)) as lon \
-            , st_box2d(the_geom) as geom_st_box2d \
+            , st_y(st_transform(st_centroid(the_geom),4326)) as lat \
+            , st_x(st_transform(st_centroid(the_geom),4326)) as lon \
+            , box2d(the_geom) as geom_st_box2d \
             , id::text as feature_id \
         from geol.rohstoffe_kohlen_bitumen_erdgas
 }
@@ -1482,9 +1482,9 @@ source src_ch_swisstopo_verschiebungsvektoren-tsp1 : def_searchable_features
           , remove_accents(name) as detail \
           , 'ch.swisstopo.verschiebungsvektoren-tsp1' as layer \
           , quadindex(the_geom) as geom_quadindex \
-          , y(st_transform(st_ClosestPoint(the_geom,st_centroid(the_geom)),4326)) as lat \
-          , x(st_transform(st_ClosestPoint(the_geom,st_centroid(the_geom)),4326)) as lon \
-          , st_box2d(the_geom) as geom_st_box2d \
+          , st_y(st_transform(st_ClosestPoint(the_geom,st_centroid(the_geom)),4326)) as lat \
+          , st_x(st_transform(st_ClosestPoint(the_geom,st_centroid(the_geom)),4326)) as lon \
+          , box2d(the_geom) as geom_st_box2d \
           , id::text as feature_id \
       from geodaesie.verschiebungsvektoren_tsp1
 }
@@ -1499,9 +1499,9 @@ source src_ch_swisstopo_verschiebungsvektoren-tsp2 : def_searchable_features
           , remove_accents(name) as detail \
           , 'ch.swisstopo.verschiebungsvektoren-tsp2' as layer \
           , quadindex(the_geom) as geom_quadindex \
-          , y(st_transform(st_ClosestPoint(the_geom,st_centroid(the_geom)),4326)) as lat \
-          , x(st_transform(st_ClosestPoint(the_geom,st_centroid(the_geom)),4326)) as lon \
-          , st_box2d(the_geom) as geom_st_box2d \
+          , st_y(st_transform(st_ClosestPoint(the_geom,st_centroid(the_geom)),4326)) as lat \
+          , st_x(st_transform(st_ClosestPoint(the_geom,st_centroid(the_geom)),4326)) as lon \
+          , box2d(the_geom) as geom_st_box2d \
           , id::text as feature_id \
       from geodaesie.verschiebungsvektoren_tsp2
 }
@@ -1516,9 +1516,9 @@ source src_ch_swisstopo_geologie-rohstoffe-vererzungen : def_searchable_features
           , remove_accents(name_ads) as detail \
           , 'ch.swisstopo.geologie-rohstoffe-vererzungen' as layer \
           , quadindex(the_geom) as geom_quadindex \
-          , y(st_transform(st_centroid(the_geom),4326)) as lat \
-          , x(st_transform(st_centroid(the_geom),4326)) as lon \
-          , st_box2d(the_geom) as geom_st_box2d \
+          , st_y(st_transform(st_centroid(the_geom),4326)) as lat \
+          , st_x(st_transform(st_centroid(the_geom),4326)) as lon \
+          , box2d(the_geom) as geom_st_box2d \
           , id::text as feature_id \
       from geol.rohstoffe_vererzungen
 }
@@ -1533,9 +1533,9 @@ source src_ch_swisstopo_geologie-geotechnik-ziegeleien_1907 : def_searchable_fea
           , remove_accents(ziegelei_2) as detail \
           , 'ch.swisstopo.geologie-geotechnik-ziegeleien_1907' as layer \
           , quadindex(the_geom) as geom_quadindex \
-          , y(st_transform(st_centroid(the_geom),4326)) as lat \
-          , x(st_transform(st_centroid(the_geom),4326)) as lon \
-          , st_box2d(the_geom) as geom_st_box2d \
+          , st_y(st_transform(st_centroid(the_geom),4326)) as lat \
+          , st_x(st_transform(st_centroid(the_geom),4326)) as lon \
+          , box2d(the_geom) as geom_st_box2d \
           , id::text as feature_id \
       from geol.geotechnik_ziegeleien_1907
 }
@@ -1550,9 +1550,9 @@ source src_ch_swisstopo_geologie-geotechnik-ziegeleien_1965 : def_searchable_fea
           , remove_accents(ziegelei) as detail \
           , 'ch.swisstopo.geologie-geotechnik-ziegeleien_1965' as layer \
           , quadindex(the_geom) as geom_quadindex \
-          , y(st_transform(st_centroid(the_geom),4326)) as lat \
-          , x(st_transform(st_centroid(the_geom),4326)) as lon \
-          , st_box2d(the_geom) as geom_st_box2d \
+          , st_y(st_transform(st_centroid(the_geom),4326)) as lat \
+          , st_x(st_transform(st_centroid(the_geom),4326)) as lon \
+          , box2d(the_geom) as geom_st_box2d \
           , id::text as feature_id \
       from geol.geotechnik_ziegeleien_1965
 }
@@ -1567,9 +1567,9 @@ source src_ch_swisstopo_geologie-geotechnik-ziegeleien_1995 : def_searchable_fea
           , remove_accents(ziegeleien) as detail \
           , 'ch.swisstopo.geologie-geotechnik-ziegeleien_1995' as layer \
           , quadindex(the_geom) as geom_quadindex \
-          , y(st_transform(st_centroid(the_geom),4326)) as lat \
-          , x(st_transform(st_centroid(the_geom),4326)) as lon \
-          , st_box2d(the_geom) as geom_st_box2d \
+          , st_y(st_transform(st_centroid(the_geom),4326)) as lat \
+          , st_x(st_transform(st_centroid(the_geom),4326)) as lon \
+          , box2d(the_geom) as geom_st_box2d \
           , id::text as feature_id \
       from geol.geotechnik_ziegeleien_1995
 }
@@ -1584,9 +1584,9 @@ source src_ch_swisstopo_geologie-gisgeol-punkte : def_searchable_features
           , remove_accents(sgd_nr::text) as detail \
           , 'ch.swisstopo.geologie-gisgeol-punkte' as layer \
           , quadindex(the_geom) as geom_quadindex \
-          , y(st_transform(st_centroid(the_geom),4326)) as lat \
-          , x(st_transform(st_centroid(the_geom),4326)) as lon \
-          , st_box2d(the_geom) as geom_st_box2d \
+          , st_y(st_transform(st_centroid(the_geom),4326)) as lat \
+          , st_x(st_transform(st_centroid(the_geom),4326)) as lon \
+          , box2d(the_geom) as geom_st_box2d \
           , gid::text as feature_id \
       from geol.view_gisgeol_points
 }
@@ -1601,9 +1601,9 @@ source src_ch_swisstopo_geologie-gisgeol-linien : def_searchable_features
           , remove_accents(sgd_nr::text) as detail \
           , 'ch.swisstopo.geologie-gisgeol-linien' as layer \
           , quadindex(the_geom) as geom_quadindex \
-          , y(st_transform(st_ClosestPoint(the_geom,st_centroid(the_geom)),4326)) as lat \
-          , x(st_transform(st_ClosestPoint(the_geom,st_centroid(the_geom)),4326)) as lon \
-          , st_box2d(the_geom) as geom_st_box2d \
+          , st_y(st_transform(st_ClosestPoint(the_geom,st_centroid(the_geom)),4326)) as lat \
+          , st_x(st_transform(st_ClosestPoint(the_geom,st_centroid(the_geom)),4326)) as lon \
+          , box2d(the_geom) as geom_st_box2d \
           , gid::text as feature_id \
       from geol.view_gisgeol_lines
 }
@@ -1618,9 +1618,9 @@ source src_ch_swisstopo_geologie-gisgeol-flaechen-1x1km : def_searchable_feature
           , remove_accents(sgd_nr::text) as detail \
           , 'ch.swisstopo.geologie-gisgeol-flaechen-1x1km' as layer \
           , quadindex(the_geom) as geom_quadindex \
-          , y(st_transform(ST_PointOnSurface(the_geom),4326)) as lat \
-          , x(st_transform(ST_PointOnSurface(the_geom),4326)) as lon \
-          , st_box2d(the_geom) as geom_st_box2d \
+          , st_y(st_transform(ST_PointOnSurface(the_geom),4326)) as lat \
+          , st_x(st_transform(ST_PointOnSurface(the_geom),4326)) as lon \
+          , box2d(the_geom) as geom_st_box2d \
           , gid::text as feature_id \
       from geol.view_gisgeol_surfaces_1x1km
 }
@@ -1635,9 +1635,9 @@ source src_ch_swisstopo_geologie-gisgeol-flaechen-10x10km : def_searchable_featu
           , remove_accents(sgd_nr::text) as detail \
           , 'ch.swisstopo.geologie-gisgeol-flaechen-10x10km' as layer \
           , quadindex(the_geom) as geom_quadindex \
-          , y(st_transform(ST_PointOnSurface(the_geom),4326)) as lat \
-          , x(st_transform(ST_PointOnSurface(the_geom),4326)) as lon \
-          , st_box2d(the_geom) as geom_st_box2d \
+          , st_y(st_transform(ST_PointOnSurface(the_geom),4326)) as lat \
+          , st_x(st_transform(ST_PointOnSurface(the_geom),4326)) as lon \
+          , box2d(the_geom) as geom_st_box2d \
           , gid::text as feature_id \
       from geol.view_gisgeol_surfaces_10x10km
 }
@@ -1652,9 +1652,9 @@ source src_ch_swisstopo_geologie-gisgeol-flaechen-10to21000km2 : def_searchable_
           , remove_accents(sgd_nr::text) as detail \
           , 'ch.swisstopo.geologie-gisgeol-flaechen-10to21000km2' as layer \
           , quadindex(the_geom) as geom_quadindex \
-          , y(st_transform(ST_PointOnSurface(the_geom),4326)) as lat \
-          , x(st_transform(ST_PointOnSurface(the_geom),4326)) as lon \
-          , st_box2d(the_geom) as geom_st_box2d \
+          , st_y(st_transform(ST_PointOnSurface(the_geom),4326)) as lat \
+          , st_x(st_transform(ST_PointOnSurface(the_geom),4326)) as lon \
+          , box2d(the_geom) as geom_st_box2d \
           , gid::text as feature_id \
       from geol.view_gisgeol_surfaces_10to21000km2
 }
@@ -1669,9 +1669,9 @@ source src_ch_swisstopo_geologie-gisgeol-flaechen-gt21000km2 : def_searchable_fe
           , remove_accents(sgd_nr::text) as detail \
           , 'ch.swisstopo.geologie-gisgeol-flaechen-gt21000km2' as layer \
           , quadindex(the_geom) as geom_quadindex \
-          , y(st_transform(ST_PointOnSurface(the_geom),4326)) as lat \
-          , x(st_transform(ST_PointOnSurface(the_geom),4326)) as lon \
-          , st_box2d(the_geom) as geom_st_box2d \
+          , st_y(st_transform(ST_PointOnSurface(the_geom),4326)) as lat \
+          , st_x(st_transform(ST_PointOnSurface(the_geom),4326)) as lon \
+          , box2d(the_geom) as geom_st_box2d \
           , gid::text as feature_id \
       from geol.view_gisgeol_surfaces_gt21000km2
 }
@@ -1686,9 +1686,9 @@ source src_ch_swisstopo_geologie-gisgeol-flaechen-lt10km2 : def_searchable_featu
           , remove_accents(sgd_nr::text) as detail \
           , 'ch.swisstopo.geologie-gisgeol-flaechen-lt10km2' as layer \
           , quadindex(the_geom) as geom_quadindex \
-          , y(st_transform(ST_PointOnSurface(the_geom),4326)) as lat \
-          , x(st_transform(ST_PointOnSurface(the_geom),4326)) as lon \
-          , st_box2d(the_geom) as geom_st_box2d \
+          , st_y(st_transform(ST_PointOnSurface(the_geom),4326)) as lat \
+          , st_x(st_transform(ST_PointOnSurface(the_geom),4326)) as lon \
+          , box2d(the_geom) as geom_st_box2d \
           , gid::text as feature_id \
       from geol.view_gisgeol_surfaces_lt10km2
 }

--- a/conf/uvek.conf.part
+++ b/conf/uvek.conf.part
@@ -10,9 +10,9 @@ source src_ch_astra_unfaelle-personenschaeden_alle : def_queryable_features
             , 'feature' as origin \
             , 'ch.astra.unfaelle-personenschaeden_alle' as layer \
             , quadindex(the_geom) as geom_quadindex \
-            , y(st_transform(st_centroid(the_geom),4326)) as lat \
-            , x(st_transform(st_centroid(the_geom),4326)) as lon \
-            , st_box2d(the_geom) as geom_st_box2d \
+            , st_y(st_transform(st_centroid(the_geom),4326)) as lat \
+            , st_x(st_transform(st_centroid(the_geom),4326)) as lon \
+            , box2d(the_geom) as geom_st_box2d \
             , accidentday_de::text as label \
             , accidentday_de::text as label_de \
             , accidentday_fr::text as label_fr \
@@ -29,9 +29,9 @@ source src_ch_astra_unfaelle-personenschaeden_fahrraeder : def_queryable_feature
             , 'feature' as origin \
             , 'ch.astra.unfaelle-personenschaeden_fahrraeder' as layer \
             , quadindex(the_geom) as geom_quadindex \
-            , y(st_transform(st_centroid(the_geom),4326)) as lat \
-            , x(st_transform(st_centroid(the_geom),4326)) as lon \
-            , st_box2d(the_geom) as geom_st_box2d \
+            , st_y(st_transform(st_centroid(the_geom),4326)) as lat \
+            , st_x(st_transform(st_centroid(the_geom),4326)) as lon \
+            , box2d(the_geom) as geom_st_box2d \
             , accidentday_de::text as label \
             , accidentday_de::text as label_de \
             , accidentday_fr::text as label_fr \
@@ -48,9 +48,9 @@ source src_ch_astra_unfaelle-personenschaeden_fussgaenger : def_queryable_featur
             , 'feature' as origin \
             , 'ch.astra.unfaelle-personenschaeden_fussgaenger' as layer \
             , quadindex(the_geom) as geom_quadindex \
-            , y(st_transform(st_centroid(the_geom),4326)) as lat \
-            , x(st_transform(st_centroid(the_geom),4326)) as lon \
-            , st_box2d(the_geom) as geom_st_box2d \
+            , st_y(st_transform(st_centroid(the_geom),4326)) as lat \
+            , st_x(st_transform(st_centroid(the_geom),4326)) as lon \
+            , box2d(the_geom) as geom_st_box2d \
             , accidentday_de::text as label \
             , accidentday_de::text as label_de \
             , accidentday_fr::text as label_fr \
@@ -67,9 +67,9 @@ source src_ch_astra_unfaelle-personenschaeden_getoetete : def_queryable_features
             , 'feature' as origin \
             , 'ch.astra.unfaelle-personenschaeden_getoetete' as layer \
             , quadindex(the_geom) as geom_quadindex \
-            , y(st_transform(st_centroid(the_geom),4326)) as lat \
-            , x(st_transform(st_centroid(the_geom),4326)) as lon \
-            , st_box2d(the_geom) as geom_st_box2d \
+            , st_y(st_transform(st_centroid(the_geom),4326)) as lat \
+            , st_x(st_transform(st_centroid(the_geom),4326)) as lon \
+            , box2d(the_geom) as geom_st_box2d \
             , accidentday_de::text as label \
             , accidentday_de::text as label_de \
             , accidentday_fr::text as label_fr \
@@ -86,9 +86,9 @@ source src_ch_astra_unfaelle-personenschaeden_motorraeder : def_queryable_featur
             , 'feature' as origin \
             , 'ch.astra.unfaelle-personenschaeden_motorraeder' as layer \
             , quadindex(the_geom) as geom_quadindex \
-            , y(st_transform(st_centroid(the_geom),4326)) as lat \
-            , x(st_transform(st_centroid(the_geom),4326)) as lon \
-            , st_box2d(the_geom) as geom_st_box2d \
+            , st_y(st_transform(st_centroid(the_geom),4326)) as lat \
+            , st_x(st_transform(st_centroid(the_geom),4326)) as lon \
+            , box2d(the_geom) as geom_st_box2d \
             , accidentday_de::text as label \
             , accidentday_de::text as label_de \
             , accidentday_fr::text as label_fr \
@@ -105,9 +105,9 @@ source src_ch_astra_ausnahmetransportrouten : def_queryable_features
             , 'feature' as origin \
             , 'ch.astra.ausnahmetransportrouten' as layer \
             , quadindex(the_geom) as geom_quadindex \
-            , y(st_transform(st_centroid(the_geom),4326)) as lat \
-            , x(st_transform(st_centroid(the_geom),4326)) as lon \
-            , st_box2d(the_geom) as geom_st_box2d \
+            , st_y(st_transform(st_centroid(the_geom),4326)) as lat \
+            , st_x(st_transform(st_centroid(the_geom),4326)) as lon \
+            , box2d(the_geom) as geom_st_box2d \
             , id::text as label \
             , id::text as feature_id \
         FROM astra.ausnahmetransportrouten WHERE (routentyp_id <> 0 AND routentyp_id <> 10)
@@ -121,9 +121,9 @@ source src_ch_bfe_abgeltung-wasserkraftnutzung : def_queryable_features
             , 'feature' as origin \
             , 'ch.bfe.abgeltung-wasserkraftnutzung' as layer \
             , quadindex(the_geom) as geom_quadindex \
-            , y(st_transform(st_centroid(the_geom),4326)) as lat \
-            , x(st_transform(st_centroid(the_geom),4326)) as lon \
-            , st_box2d(the_geom) as geom_st_box2d \
+            , st_y(st_transform(st_centroid(the_geom),4326)) as lat \
+            , st_x(st_transform(st_centroid(the_geom),4326)) as lon \
+            , box2d(the_geom) as geom_st_box2d \
             , name::text as label \
             , objectnumber::text as feature_id \
         FROM bfe.abgeltung_wasserkraftnutzung
@@ -137,9 +137,9 @@ source src_ch_bfe_energieforschung : def_queryable_features
             , 'feature' as origin \
             , 'ch.bfe.energieforschung' as layer \
             , quadindex(the_geom) as geom_quadindex \
-            , y(st_transform(st_centroid(the_geom),4326)) as lat \
-            , x(st_transform(st_centroid(the_geom),4326)) as lon \
-            , st_box2d(the_geom) as geom_st_box2d \
+            , st_y(st_transform(st_centroid(the_geom),4326)) as lat \
+            , st_x(st_transform(st_centroid(the_geom),4326)) as lon \
+            , box2d(the_geom) as geom_st_box2d \
             , titel_de::text as label \
             , tid::text as feature_id \
         FROM bfe.energieforschung
@@ -153,9 +153,9 @@ source src_ch_bfe_statistik-wasserkraftanlagen : def_queryable_features
             , 'feature' as origin \
             , 'ch.bfe.statistik-wasserkraftanlagen' as layer \
             , quadindex(the_geom) as geom_quadindex \
-            , y(st_transform(st_centroid(the_geom),4326)) as lat \
-            , x(st_transform(st_centroid(the_geom),4326)) as lon \
-            , st_box2d(the_geom) as geom_st_box2d \
+            , st_y(st_transform(st_centroid(the_geom),4326)) as lat \
+            , st_x(st_transform(st_centroid(the_geom),4326)) as lon \
+            , box2d(the_geom) as geom_st_box2d \
             , name::text as label \
             , wastanumber::text as feature_id \
         FROM bfe.statistik_wasserkraftanlagen_powerplant
@@ -169,9 +169,9 @@ source src_ch_bfe_stauanlagen-bundesaufsicht : def_queryable_features
             , 'feature' as origin \
             , 'ch.bfe.stauanlagen-bundesaufsicht' as layer \
             , quadindex(the_geom) as geom_quadindex \
-            , y(st_transform(st_centroid(the_geom),4326)) as lat \
-            , x(st_transform(st_centroid(the_geom),4326)) as lon \
-            , st_box2d(the_geom) as geom_st_box2d \
+            , st_y(st_transform(st_centroid(the_geom),4326)) as lat \
+            , st_x(st_transform(st_centroid(the_geom),4326)) as lon \
+            , box2d(the_geom) as geom_st_box2d \
             , damname::text as label \
             , dam_stabil_id::text as feature_id \
         FROM bfe.stauanlagen_bundesaufsicht
@@ -185,9 +185,9 @@ source src_ch_bfe_kleinwasserkraftpotentiale : def_queryable_features
             , 'feature' as origin \
             , 'ch.bfe.kleinwasserkraftpotentiale' as layer \
             , quadindex(the_geom) as geom_quadindex \
-            , y(st_transform(st_centroid(the_geom),4326)) as lat \
-            , x(st_transform(st_centroid(the_geom),4326)) as lon \
-            , st_box2d(the_geom) as geom_st_box2d \
+            , st_y(st_transform(st_centroid(the_geom),4326)) as lat \
+            , st_x(st_transform(st_centroid(the_geom),4326)) as lon \
+            , box2d(the_geom) as geom_st_box2d \
             , gwlnr::text as label \
             , bgdi_id::text as feature_id \
         FROM bfe.kleinwasserkraftpotentiale
@@ -201,9 +201,9 @@ source src_ch_bakom_mobil-antennenstandorte-gsm : def_queryable_features
             , 'feature' as origin \
             , 'ch.bakom.mobil-antennenstandorte-gsm' as layer \
             , quadindex(the_geom) as geom_quadindex \
-            , y(st_transform(st_centroid(the_geom),4326)) as lat \
-            , x(st_transform(st_centroid(the_geom),4326)) as lon \
-            , st_box2d(the_geom) as geom_st_box2d \
+            , st_y(st_transform(st_centroid(the_geom),4326)) as lat \
+            , st_x(st_transform(st_centroid(the_geom),4326)) as lon \
+            , box2d(the_geom) as geom_st_box2d \
             , powercode::text as label \
             , id::text as feature_id \
         FROM bakom.nisdb_gsm
@@ -217,9 +217,9 @@ source src_ch_bakom_mobil-antennenstandorte-umts : def_queryable_features
             , 'feature' as origin \
             , 'ch.bakom.mobil-antennenstandorte-umts' as layer \
             , quadindex(the_geom) as geom_quadindex \
-            , y(st_transform(st_centroid(the_geom),4326)) as lat \
-            , x(st_transform(st_centroid(the_geom),4326)) as lon \
-            , st_box2d(the_geom) as geom_st_box2d \
+            , st_y(st_transform(st_centroid(the_geom),4326)) as lat \
+            , st_x(st_transform(st_centroid(the_geom),4326)) as lon \
+            , box2d(the_geom) as geom_st_box2d \
             , powercode::text as label \
             , id::text as feature_id \
         FROM bakom.nisdb_umts
@@ -233,9 +233,9 @@ source src_ch_bakom_mobil-antennenstandorte-lte : def_queryable_features
             , 'feature' as origin \
             , 'ch.bakom.mobil-antennenstandorte-lte' as layer \
             , quadindex(the_geom) as geom_quadindex \
-            , y(st_transform(st_centroid(the_geom),4326)) as lat \
-            , x(st_transform(st_centroid(the_geom),4326)) as lon \
-            , st_box2d(the_geom) as geom_st_box2d \
+            , st_y(st_transform(st_centroid(the_geom),4326)) as lat \
+            , st_x(st_transform(st_centroid(the_geom),4326)) as lon \
+            , box2d(the_geom) as geom_st_box2d \
             , powercode::text as label \
             , id::text as feature_id \
         FROM bakom.nisdb_lte
@@ -249,9 +249,9 @@ source src_ch_bazl_projektierungszonen-flughafenanlagen : def_queryable_features
             , 'feature' as origin \
             , 'ch.bazl.projektierungszonen-flughafenanlagen' as layer \
             , quadindex(the_geom) as geom_quadindex \
-            , y(st_transform(st_centroid(the_geom),4326)) as lat \
-            , x(st_transform(st_centroid(the_geom),4326)) as lon \
-            , st_box2d(the_geom) as geom_st_box2d \
+            , st_y(st_transform(st_centroid(the_geom),4326)) as lat \
+            , st_x(st_transform(st_centroid(the_geom),4326)) as lon \
+            , box2d(the_geom) as geom_st_box2d \
             , municipality ::text as label \
             , stabil_id::text as feature_id \
         FROM bazl.projektierungszonen
@@ -265,9 +265,9 @@ source src_ch_bazl_luftfahrthindernis : def_queryable_features
             , 'feature' as origin \
             , 'ch.bazl.luftfahrthindernis' as layer \
             , quadindex(the_geom) as geom_quadindex \
-            , y(st_transform(st_centroid(the_geom),4326)) as lat \
-            , x(st_transform(st_centroid(the_geom),4326)) as lon \
-            , st_box2d(the_geom) as geom_st_box2d \
+            , st_y(st_transform(st_centroid(the_geom),4326)) as lat \
+            , st_x(st_transform(st_centroid(the_geom),4326)) as lon \
+            , box2d(the_geom) as geom_st_box2d \
             , obstacletype::text as label \
             , bgdi_id::text as feature_id \
         FROM bazl.luftfahrthindernis
@@ -281,9 +281,9 @@ source src_ch_bfe_sachplan-geologie-tiefenlager_1 : def_queryable_features
             , 'feature' as origin \
             , 'ch.bfe.sachplan-geologie-tiefenlager' as layer \
             , quadindex(the_geom) as geom_quadindex \
-            , y(st_transform(st_centroid(the_geom),4326)) as lat \
-            , x(st_transform(st_centroid(the_geom),4326)) as lon \
-            , st_box2d(the_geom) as geom_st_box2d \
+            , st_y(st_transform(st_centroid(the_geom),4326)) as lat \
+            , st_x(st_transform(st_centroid(the_geom),4326)) as lon \
+            , box2d(the_geom) as geom_st_box2d \
             , facname_de::text as label \
             , stabil_id::text as feature_id \
         FROM bfe.geologische_tiefenlager_fac
@@ -297,9 +297,9 @@ source src_ch_bfe_sachplan-geologie-tiefenlager_2 : def_queryable_features
             , 'feature' as origin \
             , 'ch.bfe.sachplan-geologie-tiefenlager' as layer \
             , quadindex(the_geom) as geom_quadindex \
-            , y(st_transform(st_centroid(the_geom),4326)) as lat \
-            , x(st_transform(st_centroid(the_geom),4326)) as lon \
-            , st_box2d(the_geom) as geom_st_box2d \
+            , st_y(st_transform(st_centroid(the_geom),4326)) as lat \
+            , st_x(st_transform(st_centroid(the_geom),4326)) as lon \
+            , box2d(the_geom) as geom_st_box2d \
             , facname_de::text as label \
             , stabil_id::text as feature_id \
         FROM bfe.geologische_tiefenlager
@@ -313,9 +313,9 @@ source src_ch_bfe_sachplan-geologie-tiefenlager_3 : def_queryable_features
             , 'feature' as origin \
             , 'ch.bfe.sachplan-geologie-tiefenlager' as layer \
             , quadindex(the_geom) as geom_quadindex \
-            , y(st_transform(st_centroid(the_geom),4326)) as lat \
-            , x(st_transform(st_centroid(the_geom),4326)) as lon \
-            , st_box2d(the_geom) as geom_st_box2d \
+            , st_y(st_transform(st_centroid(the_geom),4326)) as lat \
+            , st_x(st_transform(st_centroid(the_geom),4326)) as lon \
+            , box2d(the_geom) as geom_st_box2d \
             , facname_de::text as label \
             , stabil_id::text as feature_id \
         FROM bfe.geologische_tiefenlager_raster
@@ -330,9 +330,9 @@ source src_ch_bazl_sachplan-infrastruktur-luftfahrt_anhorung_1 : def_queryable_f
             , 'feature' as origin \
             , 'ch.bazl.sachplan-infrastruktur-luftfahrt_anhorung' as layer \
             , quadindex(the_geom) as geom_quadindex \
-            , y(st_transform(st_centroid(the_geom),4326)) as lat \
-            , x(st_transform(st_centroid(the_geom),4326)) as lon \
-            , st_box2d(the_geom) as geom_st_box2d \
+            , st_y(st_transform(st_centroid(the_geom),4326)) as lat \
+            , st_x(st_transform(st_centroid(the_geom),4326)) as lon \
+            , box2d(the_geom) as geom_st_box2d \
             , objectname_de::text as label \
             , stabil_id::text as feature_id \
         FROM bazl.sachplan_inf_luft_facilities_anhorung
@@ -346,9 +346,9 @@ source src_ch_bazl_sachplan-infrastruktur-luftfahrt_anhorung_2 : def_queryable_f
             , 'feature' as origin \
             , 'ch.bazl.sachplan-infrastruktur-luftfahrt_anhorung' as layer \
             , quadindex(the_geom) as geom_quadindex \
-            , y(st_transform(st_centroid(the_geom),4326)) as lat \
-            , x(st_transform(st_centroid(the_geom),4326)) as lon \
-            , st_box2d(the_geom) as geom_st_box2d \
+            , st_y(st_transform(st_centroid(the_geom),4326)) as lat \
+            , st_x(st_transform(st_centroid(the_geom),4326)) as lon \
+            , box2d(the_geom) as geom_st_box2d \
             , objectname_de::text as label \
             , stabil_id::text as feature_id \
         FROM bazl.sachplan_inf_luft_plmeasures_anhorung
@@ -362,9 +362,9 @@ source src_ch_bazl_sachplan-infrastruktur-luftfahrt_anhorung_3 : def_queryable_f
             , 'feature' as origin \
             , 'ch.bazl.sachplan-infrastruktur-luftfahrt_anhorung' as layer \
             , quadindex(the_geom) as geom_quadindex \
-            , y(st_transform(st_centroid(the_geom),4326)) as lat \
-            , x(st_transform(st_centroid(the_geom),4326)) as lon \
-            , st_box2d(the_geom) as geom_st_box2d \
+            , st_y(st_transform(st_centroid(the_geom),4326)) as lat \
+            , st_x(st_transform(st_centroid(the_geom),4326)) as lon \
+            , box2d(the_geom) as geom_st_box2d \
             , objectname_de::text as label \
             , stabil_id::text as feature_id \
         FROM bazl.sachplan_inf_luft_plmeasures_r_anhorung
@@ -378,9 +378,9 @@ source src_ch_bazl_sachplan-infrastruktur-luftfahrt_kraft_1 : def_queryable_feat
             , 'feature' as origin \
             , 'ch.bazl.sachplan-infrastruktur-luftfahrt_kraft' as layer \
             , quadindex(the_geom) as geom_quadindex \
-            , y(st_transform(st_centroid(the_geom),4326)) as lat \
-            , x(st_transform(st_centroid(the_geom),4326)) as lon \
-            , st_box2d(the_geom) as geom_st_box2d \
+            , st_y(st_transform(st_centroid(the_geom),4326)) as lat \
+            , st_x(st_transform(st_centroid(the_geom),4326)) as lon \
+            , box2d(the_geom) as geom_st_box2d \
             , objectname_de::text as label \
             , stabil_id::text as feature_id \
         FROM bazl.sachplan_inf_luft_facilities_kraft
@@ -394,9 +394,9 @@ source src_ch_bazl_sachplan-infrastruktur-luftfahrt_kraft_2 : def_queryable_feat
             , 'feature' as origin \
             , 'ch.bazl.sachplan-infrastruktur-luftfahrt_kraft' as layer \
             , quadindex(the_geom) as geom_quadindex \
-            , y(st_transform(st_centroid(the_geom),4326)) as lat \
-            , x(st_transform(st_centroid(the_geom),4326)) as lon \
-            , st_box2d(the_geom) as geom_st_box2d \
+            , st_y(st_transform(st_centroid(the_geom),4326)) as lat \
+            , st_x(st_transform(st_centroid(the_geom),4326)) as lon \
+            , box2d(the_geom) as geom_st_box2d \
             , objectname_de::text as label \
             , stabil_id::text as feature_id \
         FROM bazl.sachplan_inf_luft_plmeasures_r_kraft
@@ -410,9 +410,9 @@ source src_ch_bakom_anbieter-eigenes_festnetz : def_queryable_features
             , 'feature' as origin \
             , 'ch.bakom.anbieter-eigenes_festnetz' as layer \
             , quadindex(the_geom) as geom_quadindex \
-            , y(st_transform(st_centroid(the_geom),4326)) as lat \
-            , x(st_transform(st_centroid(the_geom),4326)) as lon \
-            , st_box2d(the_geom) as geom_st_box2d \
+            , st_y(st_transform(st_centroid(the_geom),4326)) as lat \
+            , st_x(st_transform(st_centroid(the_geom),4326)) as lon \
+            , box2d(the_geom) as geom_st_box2d \
             , alias::text as label \
             , cellid::text as feature_id \
         FROM bakom.nga_anbieter
@@ -426,9 +426,9 @@ source src_ch_bfe_kernkraftwerke : def_queryable_features
             , 'feature' as origin \
             , 'ch.bfe.kernkraftwerke' as layer \
             , quadindex(the_geom) as geom_quadindex \
-            , y(st_transform(st_centroid(the_geom),4326)) as lat \
-            , x(st_transform(st_centroid(the_geom),4326)) as lon \
-            , st_box2d(the_geom) as geom_st_box2d \
+            , st_y(st_transform(st_centroid(the_geom),4326)) as lat \
+            , st_x(st_transform(st_centroid(the_geom),4326)) as lon \
+            , box2d(the_geom) as geom_st_box2d \
             , name::text as label \
             , plant_id::text as feature_id \
         FROM bfe.kernkraftwerke
@@ -442,9 +442,9 @@ source src_ch_bazl_sicherheitszonenplan : def_queryable_features
             , 'feature' as origin \
             , 'ch.bazl.sicherheitszonenplan' as layer \
             , quadindex(the_geom) as geom_quadindex \
-            , y(st_transform(st_centroid(the_geom),4326)) as lat \
-            , x(st_transform(st_centroid(the_geom),4326)) as lon \
-            , st_box2d(the_geom) as geom_st_box2d \
+            , st_y(st_transform(st_centroid(the_geom),4326)) as lat \
+            , st_x(st_transform(st_centroid(the_geom),4326)) as lon \
+            , box2d(the_geom) as geom_st_box2d \
             , title::text as label \
             , stabil_id::text as feature_id \
         FROM bazl.sichereitszonen
@@ -462,9 +462,9 @@ source src_ch_astra_ivs-nat : def_searchable_features
             , remove_accents(ivs_slaname)||' '||remove_accents(ivs_nummer)||' '||remove_accents(ivs_signatur) as detail \
             , 'ch.astra.ivs-nat' as layer \
             , quadindex(the_geom) as geom_quadindex \
-            , y(st_transform(st_ClosestPoint(the_geom,st_centroid(the_geom)),4326)) as lat \
-            , x(st_transform(st_ClosestPoint(the_geom,st_centroid(the_geom)),4326)) as lon \
-            , st_box2d(the_geom) as geom_st_box2d   \
+            , st_y(st_transform(st_ClosestPoint(the_geom,st_centroid(the_geom)),4326)) as lat \
+            , st_x(st_transform(st_ClosestPoint(the_geom,st_centroid(the_geom)),4326)) as lon \
+            , box2d(the_geom) as geom_st_box2d   \
             , nat_id::text as feature_id \
         from astra.ivs_nat
 }
@@ -479,9 +479,9 @@ source src_ch_astra_ivs-reg_loc_sub : def_searchable_features
             , remove_accents(ivs_slaname)||' '||remove_accents(ivs_nummer)||' '||remove_accents(ivs_signatur) as detail \
             , 'ch.astra.ivs-reg_loc' as layer \
             , quadindex(the_geom) as geom_quadindex \
-            , y(st_transform(st_ClosestPoint(the_geom,st_centroid(the_geom)),4326)) as lat \
-            , x(st_transform(st_ClosestPoint(the_geom,st_centroid(the_geom)),4326)) as lon \
-            , st_box2d(the_geom) as geom_st_box2d \
+            , st_y(st_transform(st_ClosestPoint(the_geom,st_centroid(the_geom)),4326)) as lat \
+            , st_x(st_transform(st_ClosestPoint(the_geom,st_centroid(the_geom)),4326)) as lon \
+            , box2d(the_geom) as geom_st_box2d \
             , reg_loc_id::text as feature_id \
         from astra.ivs_reg_loc \
         where ivs_kanton != 'BE'
@@ -497,9 +497,9 @@ source src_ch_astra_ivs-reg_loc_be : def_searchable_features
             , remove_accents(ivs_slaname)||' '||remove_accents(ivs_nummer)||' '||remove_accents(ivs_signatur) as detail \
             , 'ch.astra.ivs-reg_loc' as layer \
             , quadindex(the_geom) as geom_quadindex \
-            , y(st_transform(st_ClosestPoint(the_geom,st_centroid(the_geom)),4326)) as lat \
-            , x(st_transform(st_ClosestPoint(the_geom,st_centroid(the_geom)),4326)) as lon \
-            , st_box2d(the_geom) as geom_st_box2d \
+            , st_y(st_transform(st_ClosestPoint(the_geom,st_centroid(the_geom)),4326)) as lat \
+            , st_x(st_transform(st_ClosestPoint(the_geom,st_centroid(the_geom)),4326)) as lon \
+            , box2d(the_geom) as geom_st_box2d \
             , reg_loc_id::text as feature_id \
         from astra.ivs_reg_loc \
         where ivs_kanton = 'BE'
@@ -515,9 +515,9 @@ source src_ch_astra_strassenverkehrszaehlung_messstellen-uebergeordnet : def_sea
             , nr||' '||remove_accents(zaehlstellen_bezeichnung) as detail \
             , 'ch.astra.strassenverkehrszaehlung_messstellen-uebergeordnet' as layer \
             , quadindex(the_geom) as geom_quadindex \
-            , y(st_transform(st_centroid(the_geom),4326)) as lat \
-            , x(st_transform(st_centroid(the_geom),4326)) as lon \
-            , st_box2d(the_geom) as geom_st_box2d \
+            , st_y(st_transform(st_centroid(the_geom),4326)) as lat \
+            , st_x(st_transform(st_centroid(the_geom),4326)) as lon \
+            , box2d(the_geom) as geom_st_box2d \
             , nr::text as feature_id \
         from astra.verkehr_ueber
 }
@@ -532,9 +532,9 @@ source src_ch_astra_strassenverkehrszaehlung_lokal : def_searchable_features
             , nr||' '||remove_accents(zaehlstellen_bezeichnung) as detail \
             , 'ch.astra.strassenverkehrszaehlung_messstellen-regional_lokal' as layer \
             , quadindex(the_geom) as geom_quadindex \
-            , y(st_transform(st_centroid(the_geom),4326)) as lat \
-            , x(st_transform(st_centroid(the_geom),4326)) as lon \
-            , st_box2d(the_geom) as geom_st_box2d \
+            , st_y(st_transform(st_centroid(the_geom),4326)) as lat \
+            , st_x(st_transform(st_centroid(the_geom),4326)) as lon \
+            , box2d(the_geom) as geom_st_box2d \
             , nr::text as feature_id \
         from astra.verkehr_reg_loc
 }
@@ -549,9 +549,9 @@ source src_ch_bakom_radio-fernsehsender : def_searchable_features
             , remove_accents(name)||' '||remove_accents(code) as detail \
             , 'ch.bakom.radio-fernsehsender' as layer \
             , quadindex(the_geom) as geom_quadindex \
-            , y(st_transform(st_centroid(the_geom),4326)) as lat \
-            , x(st_transform(st_centroid(the_geom),4326)) as lon \
-            , st_box2d(the_geom) as geom_st_box2d \
+            , st_y(st_transform(st_centroid(the_geom),4326)) as lat \
+            , st_x(st_transform(st_centroid(the_geom),4326)) as lon \
+            , box2d(the_geom) as geom_st_box2d \
             , id::text as feature_id \
         from bakom.nisdb_bro_tooltip
 }
@@ -566,9 +566,9 @@ source src_ch_bakom_versorgungsgebiet-tv : def_searchable_features
             , remove_accents(prog) as detail \
             , 'ch.bakom.versorgungsgebiet-tv' as layer \
             , quadindex(the_geom) as geom_quadindex \
-            , y(st_transform(ST_PointOnSurface(the_geom),4326)) as lat \
-            , x(st_transform(ST_PointOnSurface(the_geom),4326)) as lon \
-            , st_box2d(the_geom) as geom_st_box2d \
+            , st_y(st_transform(ST_PointOnSurface(the_geom),4326)) as lat \
+            , st_x(st_transform(ST_PointOnSurface(the_geom),4326)) as lon \
+            , box2d(the_geom) as geom_st_box2d \
             , gid::text as feature_id \
         from bakom.tv_gebiet
 }
@@ -584,9 +584,9 @@ source src_ch_bakom_versorgungsgebiet-ukw : def_searchable_features
             , remove_accents(prog) as detail \
             , 'ch.bakom.versorgungsgebiet-ukw' as layer \
             , quadindex(the_geom) as geom_quadindex \
-            , y(st_transform(ST_PointOnSurface(the_geom),4326)) as lat \
-            , x(st_transform(ST_PointOnSurface(the_geom),4326)) as lon \
-            , st_box2d(the_geom) as geom_st_box2d \
+            , st_y(st_transform(ST_PointOnSurface(the_geom),4326)) as lat \
+            , st_x(st_transform(ST_PointOnSurface(the_geom),4326)) as lon \
+            , box2d(the_geom) as geom_st_box2d \
             , gid::text as feature_id \
         from bakom.ukw_gebiet
 }
@@ -601,9 +601,9 @@ source src_ch_bav_kataster-belasteter-standorte-oev : def_searchable_features
             , coalesce(katasternummer::text,'') as detail \
             , 'ch.bav.kataster-belasteter-standorte-oev' as layer \
             , quadindex(the_geom) as geom_quadindex \
-            , y(st_transform(st_centroid(the_geom),4326)) as lat \
-            , x(st_transform(st_centroid(the_geom),4326)) as lon \
-            , st_box2d(the_geom) as geom_st_box2d \
+            , st_y(st_transform(st_centroid(the_geom),4326)) as lat \
+            , st_x(st_transform(st_centroid(the_geom),4326)) as lon \
+            , box2d(the_geom) as geom_st_box2d \
             , vflz_id::text as feature_id \
         FROM bav.kataster_belasteter_standorte_oev
 }
@@ -618,9 +618,9 @@ source src_ch_bazl_kataster-belasteter-standorte-zivilflugplaetze : def_searchab
           , remove_accents(coalesce(katasternummer::text,'')) as detail \
           , 'ch.bazl.kataster-belasteter-standorte-zivilflugplaetze' as layer \
           , quadindex(the_geom) as geom_quadindex \
-          , y(st_transform(st_centroid(the_geom),4326)) as lat \
-          , x(st_transform(st_centroid(the_geom),4326)) as lon \
-          , st_box2d(the_geom) as geom_st_box2d \
+          , st_y(st_transform(st_centroid(the_geom),4326)) as lat \
+          , st_x(st_transform(st_centroid(the_geom),4326)) as lon \
+          , box2d(the_geom) as geom_st_box2d \
           , vflz_id::text as feature_id \
       FROM bazl.kataster_belasteter_standorte_zivflpl
 }
@@ -635,9 +635,9 @@ source src_ch_bav_sachplan-infrastruktur-schiene_ausgangslage : def_searchable_f
             , remove_accents(name)||' '||remove_accents(description_de)||' '||remove_accents(description_fr)||' '||remove_accents(description_it)||' '||remove_accents(anlage_id)  as detail \
             , 'ch.bav.sachplan-infrastruktur-schiene_ausgangslage' as layer \
             , quadindex(the_geom) as geom_quadindex \
-            , y(st_transform(st_ClosestPoint(the_geom,st_centroid(the_geom)),4326)) as lat \
-            , x(st_transform(st_ClosestPoint(the_geom,st_centroid(the_geom)),4326)) as lon \
-            , st_box2d(the_geom) as geom_st_box2d \
+            , st_y(st_transform(st_ClosestPoint(the_geom,st_centroid(the_geom)),4326)) as lat \
+            , st_x(st_transform(st_ClosestPoint(the_geom,st_centroid(the_geom)),4326)) as lon \
+            , box2d(the_geom) as geom_st_box2d \
             , bgdi_id::text as feature_id \
         from bav.sis_angaben
 }
@@ -653,9 +653,9 @@ source src_ch_bav_sachplan-infrastruktur-schiene_anhorung_1 : def_searchable_fea
             , remove_accents(facname_de)||' '||remove_accents(facname_fr)||' '||remove_accents(facname_it)||' '||remove_accents(doc_title)||' '||remove_accents(stabil_id)  as detail \
             , 'ch.bav.sachplan-infrastruktur-schiene_anhorung' as layer \
             , quadindex(the_geom) as geom_quadindex \
-            , y(st_transform(st_centroid(the_geom),4326)) as lat \
-            , x(st_transform(st_centroid(the_geom),4326)) as lon \
-            , st_box2d(the_geom) as geom_st_box2d \
+            , st_y(st_transform(st_centroid(the_geom),4326)) as lat \
+            , st_x(st_transform(st_centroid(the_geom),4326)) as lon \
+            , box2d(the_geom) as geom_st_box2d \
             , stabil_id::text as feature_id \
         from bav.sis_fac_anhorung
 }
@@ -670,9 +670,9 @@ source src_ch_bav_sachplan-infrastruktur-schiene_anhorung_2 : def_searchable_fea
             , remove_accents(plname_de)||' '||remove_accents(plname_fr)||' '||remove_accents(plname_it)||' '||remove_accents(doc_title)||' '||remove_accents(stabil_id)  as detail \
             , 'ch.bav.sachplan-infrastruktur-schiene_anhorung' as layer \
             , quadindex(the_geom) as geom_quadindex \
-            , y(st_transform(st_centroid(the_geom),4326)) as lat \
-            , x(st_transform(st_centroid(the_geom),4326)) as lon \
-            , st_box2d(the_geom) as geom_st_box2d \
+            , st_y(st_transform(st_centroid(the_geom),4326)) as lat \
+            , st_x(st_transform(st_centroid(the_geom),4326)) as lon \
+            , box2d(the_geom) as geom_st_box2d \
             , stabil_id::text as feature_id \
         from bav.sis_pl_r_anhorung
 }
@@ -687,9 +687,9 @@ source src_ch_bav_sachplan-infrastruktur-schiene_kraft_1 : def_searchable_featur
             , remove_accents(facname_de)||' '||remove_accents(facname_fr)||' '||remove_accents(facname_it)||' '||remove_accents(doc_title)||' '||remove_accents(stabil_id)  as detail \
             , 'ch.bav.sachplan-infrastruktur-schiene_kraft' as layer \
             , quadindex(the_geom) as geom_quadindex \
-            , y(st_transform(st_ClosestPoint(the_geom,st_centroid(the_geom)),4326)) as lat \
-            , x(st_transform(st_ClosestPoint(the_geom,st_centroid(the_geom)),4326)) as lon \
-            , st_box2d(the_geom) as geom_st_box2d \
+            , st_y(st_transform(st_ClosestPoint(the_geom,st_centroid(the_geom)),4326)) as lat \
+            , st_x(st_transform(st_ClosestPoint(the_geom,st_centroid(the_geom)),4326)) as lon \
+            , box2d(the_geom) as geom_st_box2d \
             , stabil_id::text as feature_id \
         from bav.sis_fac_kraft
 }
@@ -704,9 +704,9 @@ source src_ch_bav_sachplan-infrastruktur-schiene_kraft_2 : def_searchable_featur
             , remove_accents(plname_de)||' '||remove_accents(plname_fr)||' '||remove_accents(plname_it)||' '||remove_accents(doc_title)||' '||remove_accents(stabil_id)  as detail \
             , 'ch.bav.sachplan-infrastruktur-schiene_kraft' as layer \
             , quadindex(the_geom) as geom_quadindex \
-            , y(st_transform(st_centroid(the_geom),4326)) as lat \
-            , x(st_transform(st_centroid(the_geom),4326)) as lon \
-            , st_box2d(the_geom) as geom_st_box2d \
+            , st_y(st_transform(st_centroid(the_geom),4326)) as lat \
+            , st_x(st_transform(st_centroid(the_geom),4326)) as lon \
+            , box2d(the_geom) as geom_st_box2d \
             , stabil_id::text as feature_id \
         from bav.sis_pl_r_kraft
 }
@@ -721,9 +721,9 @@ source src_ch_bfe_energiestaedte : def_searchable_features
             , remove_accents(name) as detail \
             , 'ch.bfe.energiestaedte' as layer \
             , quadindex(the_geom) as geom_quadindex \
-            , y(st_transform(ST_PointOnSurface(the_geom),4326)) as lat \
-            , x(st_transform(ST_PointOnSurface(the_geom),4326)) as lon \
-            , st_box2d(the_geom) as geom_st_box2d \
+            , st_y(st_transform(ST_PointOnSurface(the_geom),4326)) as lat \
+            , st_x(st_transform(ST_PointOnSurface(the_geom),4326)) as lon \
+            , box2d(the_geom) as geom_st_box2d \
             , bgdi_id::text as feature_id \
         from bfe.energiestaedte
 }
@@ -738,9 +738,9 @@ source src_ch_bfe_energiestaedte-energieregionen : def_searchable_features
             , remove_accents(name) as detail \
             , 'ch.bfe.energiestaedte-energieregionen' as layer \
             , quadindex(the_geom) as geom_quadindex \
-            , y(st_transform(ST_PointOnSurface(the_geom),4326)) as lat \
-            , x(st_transform(ST_PointOnSurface(the_geom),4326)) as lon \
-            , st_box2d(the_geom) as geom_st_box2d \
+            , st_y(st_transform(ST_PointOnSurface(the_geom),4326)) as lat \
+            , st_x(st_transform(ST_PointOnSurface(the_geom),4326)) as lon \
+            , box2d(the_geom) as geom_st_box2d \
             , bgdi_id::text as feature_id \
         from bfe.energiestaedte_energieregionen
 }
@@ -755,9 +755,9 @@ source src_ch_bfe_energiestaedte-2000watt-areale : def_searchable_features
             , remove_accents(name) as detail \
             , 'ch.bfe.energiestaedte-2000watt-areale' as layer \
             , quadindex(the_geom) as geom_quadindex \
-            , y(st_transform(ST_PointOnSurface(the_geom),4326)) as lat \
-            , x(st_transform(ST_PointOnSurface(the_geom),4326)) as lon \
-            , st_box2d(the_geom) as geom_st_box2d \
+            , st_y(st_transform(ST_PointOnSurface(the_geom),4326)) as lat \
+            , st_x(st_transform(ST_PointOnSurface(the_geom),4326)) as lon \
+            , box2d(the_geom) as geom_st_box2d \
             , bgdi_id::text as feature_id \
         from bfe.energiestaedte_2000watt_areale
 }
@@ -772,9 +772,9 @@ source src_ch_bfe_energiestaedte-2000watt-aufdemweg : def_searchable_features
             , remove_accents(name) as detail \
             , 'ch.bfe.energiestaedte-2000watt-aufdemweg' as layer \
             , quadindex(the_geom) as geom_quadindex \
-            , y(st_transform(ST_PointOnSurface(the_geom),4326)) as lat \
-            , x(st_transform(ST_PointOnSurface(the_geom),4326)) as lon \
-            , st_box2d(the_geom) as geom_st_box2d \
+            , st_y(st_transform(ST_PointOnSurface(the_geom),4326)) as lat \
+            , st_x(st_transform(ST_PointOnSurface(the_geom),4326)) as lon \
+            , box2d(the_geom) as geom_st_box2d \
             , bgdi_id::text as feature_id \
         from bfe.energiestaedte_aufdemweg_2000watt
 }

--- a/conf/vbs.conf.part
+++ b/conf/vbs.conf.part
@@ -10,9 +10,9 @@ source src_ch_vbs_territorialregionen : def_queryable_features
             , 'feature' as origin \
             , 'ch.vbs.territorialregionen' as layer \
             , quadindex(the_geom) as geom_quadindex \
-            , y(st_transform(st_centroid(the_geom),4326)) as lat \
-            , x(st_transform(st_centroid(the_geom),4326)) as lon \
-            , st_box2d(the_geom) as geom_st_box2d \
+            , st_y(st_transform(st_centroid(the_geom),4326)) as lat \
+            , st_x(st_transform(st_centroid(the_geom),4326)) as lon \
+            , box2d(the_geom) as geom_st_box2d \
             , name::text as label \
             , terreg_nr::text as feature_id \
         from public.territorialregionen
@@ -30,9 +30,9 @@ source src_ch_babs_kulturgueter : def_searchable_features
             , remove_accents(zkob) as detail \
             , 'ch.babs.kulturgueter' as layer \
             , quadindex(the_geom) as geom_quadindex \
-            , y(st_transform(st_centroid(the_geom),4326)) as lat \
-            , x(st_transform(st_centroid(the_geom),4326)) as lon \
-            , st_box2d(the_geom) as geom_st_box2d \
+            , st_y(st_transform(st_centroid(the_geom),4326)) as lat \
+            , st_x(st_transform(st_centroid(the_geom),4326)) as lon \
+            , box2d(the_geom) as geom_st_box2d \
             , kgs_nr::text as feature_id \
         from babs.kgs
 }

--- a/conf/zeitreihen.conf.part
+++ b/conf/zeitreihen.conf.part
@@ -10,9 +10,9 @@ source src_ch_swisstopo_hiks-dufour : def_queryable_features
             , 'feature' as origin \
             , 'ch.swisstopo.hiks-dufour' as layer \
             , quadindex(the_geom) as geom_quadindex \
-            , y(st_transform(st_centroid(the_geom),4326)) as lat \
-            , x(st_transform(st_centroid(the_geom),4326)) as lon \
-            , st_box2d(the_geom) as geom_st_box2d \
+            , st_y(st_transform(st_centroid(the_geom),4326)) as lat \
+            , st_x(st_transform(st_centroid(the_geom),4326)) as lon \
+            , box2d(the_geom) as geom_st_box2d \
             , datenstand::text as label \
             , tilenumber::text as feature_id \
         FROM view_dufour_erstausgabe 
@@ -26,9 +26,9 @@ source src_ch_swisstopo_hiks-siegfried : def_queryable_features
             , 'feature' as origin \
             , 'ch.swisstopo.hiks-siegfried' as layer \
             , quadindex(the_geom) as geom_quadindex \
-            , y(st_transform(st_centroid(the_geom),4326)) as lat \
-            , x(st_transform(st_centroid(the_geom),4326)) as lon \
-            , st_box2d(the_geom) as geom_st_box2d \
+            , st_y(st_transform(st_centroid(the_geom),4326)) as lat \
+            , st_x(st_transform(st_centroid(the_geom),4326)) as lon \
+            , box2d(the_geom) as geom_st_box2d \
             , datenstand::text as label \
             , tilenumber::text as feature_id \
         FROM view_siegfried_erstausgabe 


### PR DESCRIPTION
This pr is removing deprecated postgis functions from index queries.
These functions are not supported anymore in postgis 2.1.4
p.e.
x(geom)
y(geom)
st_box2d(geom)
