### PR TITLE
Wordforms doc update

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,10 @@ sudo su sphinxsearch
 make move-template
 make index-all
 ```
+####Wordforms
+Wordforms are part of the sphinx conf.
+The swisssearch index (zipcodes) has to be computed after a wordforms update.
+
 ###Command line debugging with python sphinx api
 ```bash
 $ cd lib/sphinxapi


### PR DESCRIPTION
Wordforms are in rep /var/lib/sphinxsearch/data/index/

https://github.com/geoadmin/service-sphinxsearch/blob/master/deploy/deploy-conf-only.cfg#L44

They are pasted in the temp directory using the conf only deploy script.

What I'm not sure is if this : https://github.com/geoadmin/service-sphinxsearch/blob/master/deploy/hooks_conf_only/post-restore-code#L59

does rsync the wordforms files too? (it should!)

The best way to be sure of this is to test it on the next deploy after wordforms update 
(#150)
