### PR TITLE
fixes accidentally deleted indexes with move-template

### DIFF
--- a/deploy/hooks_conf_only/post-restore-code
+++ b/deploy/hooks_conf_only/post-restore-code
@@ -21,7 +21,7 @@ if [ "$*" = "clean_index" ]; then
 
     if [[ -f $sphinxconfig && -d $SPHINXINDEX ]];then
         array_config=($(grep path $sphinxconfig | awk -F"=" '{print $2}' | sed -n -e 's|^.*/||p'))
-        array_file=($(find $SPHINXINDEX -name "*.spd" | sed 's|.spd$||g' | sed -n -e 's|^.*/||p' ))
+        array_file=($(find $SPHINXINDEX -maxdepth 1 -name "*.spd" | sed 's|.spd$||g' | sed -n -e 's|^.*/||p' ))
         array_orphaned=($(comm -13 --nocheck-order <(printf '%s\n' "${array_config[@]}" | LC_ALL=C sort) <(printf '%s\n' "${array_file[@]}" | LC_ALL=C sort)))
 
         echo -e "\t${green}looking for orphaned index $a in filesystem ...${NC}"


### PR DESCRIPTION
add maxdepth 1, list the indexes should only use top level of the directory, otherwise indexes with the same name in a subfolder will be declared as orphaned and removed.

The directory /var/lib/sphinxsearch/data/index/index/ has been created during the migration from classic to vpc infrastructure. The directory has been removed.
