### PR TITLE
Add plz npa and zip prefix for zip codes

### DIFF
--- a/conf/search.conf.part
+++ b/conf/search.conf.part
@@ -148,7 +148,7 @@ source src_zipcode : src_swisssearch
         SELECT \
         gid as id \
         , os_uuid::text as feature_id \
-        , plz::text as detail \
+        , 'npa plz zip ' || plz::text as detail \
         , '<b>'||coalesce(plz::text,'')||' - '||coalesce(langtext,'')||' ('||coalesce((SELECT ak from tlm.swissboundaries_kantone k where st_intersects(ST_PointOnSurface(p.the_geom),k.the_geom)),'')||')</b>' as label \
         , 'zipcode' as origin \
         , quadindex(the_geom) as geom_quadindex \


### PR DESCRIPTION
"A small step for sphinx, a big step in for thematical search"

ref : https://github.com/geoadmin/mf-geoadmin3/issues/2327

This adds NPA/PLZ/ZIP prefix on zipcode index details

https://mf-geoadmin3.dev.bgdi.ch/?X=123325.00&Y=713100.00&zoom=0&lang=de&topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers_opacity=0.75&layers=ch.bafu.laerm-strassenlaerm_nacht

Query example :

NPA 3008
3008

[Query sample](https://mf-chsdi3.dev.bgdi.ch/rest/services/api/SearchServer?searchText=npa 300&type=locations)