### PR TITLE
Remove circular references on wordforms

### DIFF
--- a/conf/wordforms_main.txt
+++ b/conf/wordforms_main.txt
@@ -4,10 +4,6 @@ Al > Allee
 Str > Strasse
 Pl > Platz
 GI > Industriegebiet
-Strasse > Gasse
-Gasse > Strasse
-Weg > Gasse
-Platz > Strasse
 
 # francais
 ch > chemin
@@ -21,18 +17,7 @@ r > rue
 sent > sentier
 pass > passage
 # zi > zone industrielle (need 2.2.4 update)
-route > rue
-rue > route
-avenue > boulevard
-boulevard > avenue
-chemin > sentier
-sentier > chemin
-passage > vy
-vy > passage
 
 # italiano
 v > viale
 p > piazza
-viale > sentiero
-sentiero > viale
-piazza > viale


### PR DESCRIPTION
Requires an update of swisssearch indices when deploying.

Fix #203