### PR TITLE
use pg-sandbox.bgdi.ch for sphinx index creation

### DIFF
--- a/conf/db.conf.in
+++ b/conf/db.conf.in
@@ -3,7 +3,7 @@
 source def_pqsql
 {
     type = pgsql
-    sql_host = pg.bgdi.ch
+    sql_host = pg-sandbox.bgdi.ch
     sql_user = $PGUSER
     sql_pass = $PGPASS
     sql_port = 5432


### PR DESCRIPTION
sphinx should use the dedicated sandbox instance for index creation