### PR TITLE
this will improve the valdiation of the new config before moving it to

### DIFF
--- a/deploy/move-template.sh
+++ b/deploy/move-template.sh
@@ -3,7 +3,10 @@
 set -e
 # check user
 [ "$USER" = "sphinxsearch" ] || { echo "error: script has to be run with sphinxsearch" ; exit 1 ;}
+# check for sphinx.conf syntax
 indextool --checkconfig -c conf/sphinx.conf | grep "config valid"
+# check all database queries
+for db in $(grep sql_db conf/sphinx.conf | awk 'length($3) {print $3"."}' | sort | uniq); do python deploy/pg2sphinx_trigger.py -d ${db} -c list -s conf/sphinx.conf | grep -E "^[0-9]+"; done  
 cp conf/sphinx.conf /var/lib/sphinxsearch/data/index/sphinx.conf
 cp conf/wordforms_*.txt /var/lib/sphinxsearch/data/index
 cp conf/sphinx.conf /etc/sphinxsearch/sphinx.conf


### PR DESCRIPTION
We should merge this asap.
This will prevent that buggy queries, which are passing the built-in syntax checker are blocking the db deploy trigger.
Actually the db trigger will not work anymore if
* one of the sphinx queries of a database is not working
* a table deploy of this database is launching the db trigger 

We should merge this asap.
