### PR TITLE
Add new config for db evd. 

### DIFF
--- a/conf/evd.conf.part
+++ b/conf/evd.conf.part
@@ -1,0 +1,403 @@
+## SOURCES
+
+source src_ch_blw_klimaeignung_typ : def_searchable_features
+{
+    sql_db = evd_dev
+    sql_query = \
+        SELECT bgdi_id::bigint as id \
+            , klimeig_be as label \
+            , 'feature' as origin \
+            , remove_accents(coalesce(klimeig_be,' ')||' '||coalesce(zone,' ')) as detail \
+            , 'ch.blw.klimaeignung-typ' as layer \
+            , quadindex(the_geom) as geom_quadindex \
+            , st_y(st_transform(st_centroid(the_geom),4326)) as lat \
+            , st_x(st_transform(st_centroid(the_geom),4326)) as lon \
+            , box2d(the_geom) as geom_st_box2d \
+            , bgdi_id::text as feature_id \
+        from blw.klimaeignung 
+}
+
+source src_ch_blw_klimaeignung_koernermais : def_searchable_features
+{
+    sql_db = evd_dev
+    sql_query = \
+        SELECT bgdi_id::bigint as id \
+            , klimeig_be as label \
+            , 'feature' as origin \
+            , remove_accents(coalesce(klimeig_be,' ')||' '||coalesce(zone,' ')) as detail \
+            , 'ch.blw.klimaeignung-koernermais' as layer \
+            , quadindex(the_geom) as geom_quadindex \
+            , st_y(st_transform(st_centroid(the_geom),4326)) as lat \
+            , st_x(st_transform(st_centroid(the_geom),4326)) as lon \
+            , box2d(the_geom) as geom_st_box2d \
+            , bgdi_id::text as feature_id \
+        from blw.klimaeignung 
+}
+
+source src_ch_blw_klimaeignung_spezialkulturen : def_searchable_features
+{
+    sql_db = evd_dev
+    sql_query = \
+        SELECT bgdi_id::bigint as id \
+            , klimeig_be as label \
+            , 'feature' as origin \
+            , remove_accents(coalesce(klimeig_be,' ')||' '||coalesce(zone,' ')) as detail \
+            , 'ch.blw.klimaeignung-spezialkulturen' as layer \
+            , quadindex(the_geom) as geom_quadindex \
+            , st_y(st_transform(st_centroid(the_geom),4326)) as lat \
+            , st_x(st_transform(st_centroid(the_geom),4326)) as lon \
+            , box2d(the_geom) as geom_st_box2d \
+            , bgdi_id::text as feature_id \
+        from blw.klimaeignung 
+}
+
+source src_ch_blw_klimaeignung_zwischenfruchtbau : def_searchable_features
+{
+    sql_db = evd_dev
+    sql_query = \
+        SELECT bgdi_id::bigint as id \
+            , klimeig_be as label \
+            , 'feature' as origin \
+            , remove_accents(coalesce(klimeig_be,' ')||' '||coalesce(zone,' ')) as detail \
+            , 'ch.blw.klimaeignung-zwischenfruchtbau' as layer \
+            , quadindex(the_geom) as geom_quadindex \
+            , st_y(st_transform(st_centroid(the_geom),4326)) as lat \
+            , st_x(st_transform(st_centroid(the_geom),4326)) as lon \
+            , box2d(the_geom) as geom_st_box2d \
+            , bgdi_id::text as feature_id \
+        from blw.klimaeignung 
+}
+
+source src_ch_blw_klimaeignung_kartoffeln : def_searchable_features
+{
+    sql_db = evd_dev
+    sql_query = \
+        SELECT bgdi_id::bigint as id \
+            , klimeig_be as label \
+            , 'feature' as origin \
+            , remove_accents(coalesce(klimeig_be,' ')||' '||coalesce(zone,' ')) as detail \
+            , 'ch.blw.klimaeignung-kartoffeln' as layer \
+            , quadindex(the_geom) as geom_quadindex \
+            , st_y(st_transform(st_centroid(the_geom),4326)) as lat \
+            , st_x(st_transform(st_centroid(the_geom),4326)) as lon \
+            , box2d(the_geom) as geom_st_box2d \
+            , bgdi_id::text as feature_id \
+        from blw.klimaeignung 
+}
+
+source src_ch_blw_klimaeignung_getreidebau : def_searchable_features
+{
+    sql_db = evd_dev
+    sql_query = \
+        SELECT bgdi_id::bigint as id \
+            , klimeig_be as label \
+            , 'feature' as origin \
+            , remove_accents(coalesce(klimeig_be,' ')||' '||coalesce(zone,' ')) as detail \
+            , 'ch.blw.klimaeignung-getreidebau' as layer \
+            , quadindex(the_geom) as geom_quadindex \
+            , st_y(st_transform(st_centroid(the_geom),4326)) as lat \
+            , st_x(st_transform(st_centroid(the_geom),4326)) as lon \
+            , box2d(the_geom) as geom_st_box2d \
+            , bgdi_id::text as feature_id \
+        from blw.klimaeignung 
+}
+
+source src_ch_blw_klimaeignung_futterbau : def_searchable_features
+{
+    sql_db = evd_dev
+    sql_query = \
+        SELECT bgdi_id::bigint as id \
+            , klimeig_be as label \
+            , 'feature' as origin \
+            , remove_accents(coalesce(klimeig_be,' ')||' '||coalesce(zone,' ')) as detail \
+            , 'ch.blw.klimaeignung-futterbau' as layer \
+            , quadindex(the_geom) as geom_quadindex \
+            , st_y(st_transform(st_centroid(the_geom),4326)) as lat \
+            , st_x(st_transform(st_centroid(the_geom),4326)) as lon \
+            , box2d(the_geom) as geom_st_box2d \
+            , bgdi_id::text as feature_id \
+        from blw.klimaeignung 
+}
+
+source src_ch_blw_niederschlagshaushalt : def_searchable_features
+{
+    sql_db = evd_dev
+    sql_query = \
+        SELECT bgdi_id::bigint as id \
+            , klimeig_be as label \
+            , 'feature' as origin \
+            , remove_accents(coalesce(klimeig_be,' ')||' '||coalesce(zone,' ')) as detail \
+            , 'ch.blw.niederschlagshaushalt' as layer \
+            , quadindex(the_geom) as geom_quadindex \
+            , st_y(st_transform(st_centroid(the_geom),4326)) as lat \
+            , st_x(st_transform(st_centroid(the_geom),4326)) as lon \
+            , box2d(the_geom) as geom_st_box2d \
+            , bgdi_id::text as feature_id \
+        from blw.klimaeignung 
+}
+
+source src_ch_blw_klimaeignung_kulturland : def_searchable_features
+{
+    sql_db = evd_dev
+    sql_query = \
+        SELECT bgdi_id::bigint as id \
+            , klimeig_be as label \
+            , 'feature' as origin \
+            , remove_accents(coalesce(klimeig_be,' ')||' '||coalesce(zone,' ')) as detail \
+            , 'ch.blw.klimaeignung-kulturland' as layer \
+            , quadindex(the_geom) as geom_quadindex \
+            , st_y(st_transform(st_centroid(the_geom),4326)) as lat \
+            , st_x(st_transform(st_centroid(the_geom),4326)) as lon \
+            , box2d(the_geom) as geom_st_box2d \
+            , bgdi_id::text as feature_id \
+        from blw.klimaeignung 
+}
+
+source src_ch_blw_bodeneignung_kulturtyp : def_searchable_features
+{
+    sql_db = evd_dev
+    sql_query = \
+        SELECT bgdi_id::bigint as id \
+            , eignungsei as label \
+            , 'feature' as origin \
+            , remove_accents(coalesce(farbe::text,' ')||' '||coalesce(eignungsei,' ')) as detail \
+            , 'ch.blw.bodeneignung-kulturtyp' as layer \
+            , quadindex(the_geom) as geom_quadindex \
+            , st_y(st_transform(st_centroid(the_geom),4326)) as lat \
+            , st_x(st_transform(st_centroid(the_geom),4326)) as lon \
+            , box2d(the_geom) as geom_st_box2d \
+            , bgdi_id::text as feature_id \
+        from blw.bodeneignung 
+}
+
+source src_ch_blw_bodeneignung_gruendigkeit : def_searchable_features
+{
+    sql_db = evd_dev
+    sql_query = \
+        SELECT bgdi_id::bigint as id \
+            , eignungsei as label \
+            , 'feature' as origin \
+            , remove_accents(coalesce(farbe::text,' ')||' '||coalesce(eignungsei,' ')) as detail \
+            , 'ch.blw.bodeneignung-gruendigkeit' as layer \
+            , quadindex(the_geom) as geom_quadindex \
+            , st_y(st_transform(st_centroid(the_geom),4326)) as lat \
+            , st_x(st_transform(st_centroid(the_geom),4326)) as lon \
+            , box2d(the_geom) as geom_st_box2d \
+            , bgdi_id::text as feature_id \
+        from blw.bodeneignung 
+}
+
+source src_ch_blw_bodeneignung_skelettgehalt : def_searchable_features
+{
+    sql_db = evd_dev
+    sql_query = \
+        SELECT bgdi_id::bigint as id \
+            , eignungsei as label \
+            , 'feature' as origin \
+            , remove_accents(coalesce(farbe::text,' ')||' '||coalesce(eignungsei,' ')) as detail \
+            , 'ch.blw.bodeneignung-skelettgehalt' as layer \
+            , quadindex(the_geom) as geom_quadindex \
+            , st_y(st_transform(st_centroid(the_geom),4326)) as lat \
+            , st_x(st_transform(st_centroid(the_geom),4326)) as lon \
+            , box2d(the_geom) as geom_st_box2d \
+            , bgdi_id::text as feature_id \
+        from blw.bodeneignung 
+}
+
+source src_ch_blw_bodeneignung_wasserspeichervermoegen : def_searchable_features
+{
+    sql_db = evd_dev
+    sql_query = \
+        SELECT bgdi_id::bigint as id \
+            , eignungsei as label \
+            , 'feature' as origin \
+            , remove_accents(coalesce(farbe::text,' ')||' '||coalesce(eignungsei,' ')) as detail \
+            , 'ch.blw.bodeneignung-wasserspeichervermoegen' as layer \
+            , quadindex(the_geom) as geom_quadindex \
+            , st_y(st_transform(st_centroid(the_geom),4326)) as lat \
+            , st_x(st_transform(st_centroid(the_geom),4326)) as lon \
+            , box2d(the_geom) as geom_st_box2d \
+            , bgdi_id::text as feature_id \
+        from blw.bodeneignung 
+}
+
+source src_ch_blw_bodeneignung_naehrstoffspeichervermoegen : def_searchable_features
+{
+    sql_db = evd_dev
+    sql_query = \
+        SELECT bgdi_id::bigint as id \
+            , eignungsei as label \
+            , 'feature' as origin \
+            , remove_accents(coalesce(farbe::text,' ')||' '||coalesce(eignungsei,' ')) as detail \
+            , 'ch.blw.bodeneignung-naehrstoffspeichervermoegen' as layer \
+            , quadindex(the_geom) as geom_quadindex \
+            , st_y(st_transform(st_centroid(the_geom),4326)) as lat \
+            , st_x(st_transform(st_centroid(the_geom),4326)) as lon \
+            , box2d(the_geom) as geom_st_box2d \
+            , bgdi_id::text as feature_id \
+        from blw.bodeneignung 
+}
+
+source src_ch_blw_bodeneignung_wasserdurchlaessigkeit : def_searchable_features
+{
+    sql_db = evd_dev
+    sql_query = \
+        SELECT bgdi_id::bigint as id \
+            , eignungsei as label \
+            , 'feature' as origin \
+            , remove_accents(coalesce(farbe::text,' ')||' '||coalesce(eignungsei,' ')) as detail \
+            , 'ch.blw.bodeneignung-wasserdurchlaessigkeit' as layer \
+            , quadindex(the_geom) as geom_quadindex \
+            , st_y(st_transform(st_centroid(the_geom),4326)) as lat \
+            , st_x(st_transform(st_centroid(the_geom),4326)) as lon \
+            , box2d(the_geom) as geom_st_box2d \
+            , bgdi_id::text as feature_id \
+        from blw.bodeneignung 
+}
+
+source src_ch_blw_bodeneignung_vernaessung : def_searchable_features
+{
+    sql_db = evd_dev
+    sql_query = \
+        SELECT bgdi_id::bigint as id \
+            , eignungsei as label \
+            , 'feature' as origin \
+            , remove_accents(coalesce(farbe::text,' ')||' '||coalesce(eignungsei,' ')) as detail \
+            , 'ch.blw.bodeneignung-vernaessung' as layer \
+            , quadindex(the_geom) as geom_quadindex \
+            , st_y(st_transform(st_centroid(the_geom),4326)) as lat \
+            , st_x(st_transform(st_centroid(the_geom),4326)) as lon \
+            , box2d(the_geom) as geom_st_box2d \
+            , bgdi_id::text as feature_id \
+        from blw.bodeneignung 
+}
+
+source src_ch_blw_bodeneignung_kulturland : def_searchable_features
+{
+    sql_db = evd_dev
+    sql_query = \
+        SELECT bgdi_id::bigint as id \
+            , eignungsei as label \
+            , 'feature' as origin \
+            , remove_accents(coalesce(farbe::text,' ')||' '||coalesce(eignungsei,' ')) as detail \
+            , 'ch.blw.bodeneignung-kulturland' as layer \
+            , quadindex(the_geom) as geom_quadindex \
+            , st_y(st_transform(st_centroid(the_geom),4326)) as lat \
+            , st_x(st_transform(st_centroid(the_geom),4326)) as lon \
+            , box2d(the_geom) as geom_st_box2d \
+            , bgdi_id::text as feature_id \
+        from blw.bodeneignung 
+}
+
+
+## INDICES
+
+index ch_blw_klimaeignung_typ
+{
+    type = plain
+    source = src_ch_blw_klimaeignung_typ
+    path = /var/lib/sphinxsearch/data/index/ch_blw_klimaeignung_typ
+    docinfo = extern
+    charset_type = utf-8
+    min_infix_len = 2
+    infix_fields = detail
+    min_prefix_len = 1
+    prefix_fields = geom_quadindex
+    enable_star = 1
+}
+
+index ch_blw_klimaeignung_koernermais : ch_blw_klimaeignung_typ
+{
+    source = src_ch_blw_klimaeignung_koernermais
+    path = /var/lib/sphinxsearch/data/index/ch_blw_klimaeignung_koernermais
+}
+
+index ch_blw_klimaeignung_spezialkulturen : ch_blw_klimaeignung_typ
+{
+    source = src_ch_blw_klimaeignung_spezialkulturen
+    path = /var/lib/sphinxsearch/data/index/ch_blw_klimaeignung_spezialkulturen
+}
+
+index ch_blw_klimaeignung_zwischenfruchtbau : ch_blw_klimaeignung_typ
+{
+    source = src_ch_blw_klimaeignung_zwischenfruchtbau
+    path = /var/lib/sphinxsearch/data/index/ch_blw_klimaeignung_zwischenfruchtbau
+}
+
+index ch_blw_klimaeignung_kartoffeln : ch_blw_klimaeignung_typ
+{
+    source = src_ch_blw_klimaeignung_kartoffeln
+    path = /var/lib/sphinxsearch/data/index/ch_blw_klimaeignung_kartoffeln
+}
+
+index ch_blw_klimaeignung_getreidebau : ch_blw_klimaeignung_typ
+{
+    source = src_ch_blw_klimaeignung_getreidebau
+    path = /var/lib/sphinxsearch/data/index/ch_blw_klimaeignung_getreidebau
+}
+
+index ch_blw_klimaeignung_futterbau : ch_blw_klimaeignung_typ
+{
+    source = src_ch_blw_klimaeignung_futterbau
+    path = /var/lib/sphinxsearch/data/index/ch_blw_klimaeignung_futterbau
+}
+
+index ch_blw_klimaeignung_kulturland : ch_blw_klimaeignung_typ
+{
+    source = src_ch_blw_klimaeignung_kulturland
+    path = /var/lib/sphinxsearch/data/index/ch_blw_klimaeignung_kulturland
+}
+
+index ch_blw_niederschlagshaushalt : ch_blw_klimaeignung_typ
+{
+    source = src_ch_blw_niederschlagshaushalt
+    path = /var/lib/sphinxsearch/data/index/ch_blw_niederschlagshaushalt
+}
+
+index ch_blw_bodeneignung_kulturtyp : ch_blw_klimaeignung_typ
+{
+    source = src_ch_blw_bodeneignung_kulturtyp
+    path = /var/lib/sphinxsearch/data/index/ch_blw_bodeneignung_kulturtyp
+}
+
+index ch_blw_bodeneignung_gruendigkeit : ch_blw_klimaeignung_typ
+{
+    source = src_ch_blw_bodeneignung_gruendigkeit
+    path = /var/lib/sphinxsearch/data/index/ch_blw_bodeneignung_gruendigkeit
+}
+
+index ch_blw_bodeneignung_skelettgehalt : ch_blw_klimaeignung_typ
+{
+    source = src_ch_blw_bodeneignung_skelettgehalt
+    path = /var/lib/sphinxsearch/data/index/ch_blw_bodeneignung_skelettgehalt
+}
+
+index ch_blw_bodeneignung_wasserspeichervermoegen : ch_blw_klimaeignung_typ
+{
+    source = src_ch_blw_bodeneignung_wasserspeichervermoegen
+    path = /var/lib/sphinxsearch/data/index/ch_blw_bodeneignung_wasserspeichervermoegen
+}
+
+index ch_blw_bodeneignung_naehrstoffspeichervermoegen : ch_blw_klimaeignung_typ
+{
+    source = src_ch_blw_bodeneignung_naehrstoffspeichervermoegen
+    path = /var/lib/sphinxsearch/data/index/ch_blw_bodeneignung_naehrstoffspeichervermoegen
+}
+
+index ch_blw_bodeneignung_wasserdurchlaessigkeit : ch_blw_klimaeignung_typ
+{
+    source = src_ch_blw_bodeneignung_wasserdurchlaessigkeit
+    path = /var/lib/sphinxsearch/data/index/ch_blw_bodeneignung_wasserdurchlaessigkeit
+}
+
+index ch_blw_bodeneignung_vernaessung : ch_blw_klimaeignung_typ
+{
+    source = src_ch_blw_bodeneignung_vernaessung
+    path = /var/lib/sphinxsearch/data/index/ch_blw_bodeneignung_vernaessung
+}
+
+index ch_blw_bodeneignung_kulturland : ch_blw_klimaeignung_typ
+{
+    source = src_ch_blw_bodeneignung_kulturland
+    path = /var/lib/sphinxsearch/data/index/ch_blw_bodeneignung_kulturland
+}

--- a/conf/evd.conf.part
+++ b/conf/evd.conf.part
@@ -7,7 +7,7 @@ source src_ch_blw_klimaeignung_typ : def_searchable_features
         SELECT bgdi_id::bigint as id \
             , klimeig_be as label \
             , 'feature' as origin \
-            , remove_accents(coalesce(klimeig_be,' ')||' '||coalesce(zone,' ')) as detail \
+            , remove_accents(concat_ws(' ',klimeig_be,zone)) as detail \
             , 'ch.blw.klimaeignung-typ' as layer \
             , quadindex(the_geom) as geom_quadindex \
             , st_y(st_transform(st_centroid(the_geom),4326)) as lat \
@@ -24,7 +24,7 @@ source src_ch_blw_klimaeignung_koernermais : def_searchable_features
         SELECT bgdi_id::bigint as id \
             , klimeig_be as label \
             , 'feature' as origin \
-            , remove_accents(coalesce(klimeig_be,' ')||' '||coalesce(zone,' ')) as detail \
+            , remove_accents(concat_ws(' ',klimeig_be,zone)) as detail \
             , 'ch.blw.klimaeignung-koernermais' as layer \
             , quadindex(the_geom) as geom_quadindex \
             , st_y(st_transform(st_centroid(the_geom),4326)) as lat \
@@ -41,7 +41,7 @@ source src_ch_blw_klimaeignung_spezialkulturen : def_searchable_features
         SELECT bgdi_id::bigint as id \
             , klimeig_be as label \
             , 'feature' as origin \
-            , remove_accents(coalesce(klimeig_be,' ')||' '||coalesce(zone,' ')) as detail \
+            , remove_accents(concat_ws(' ',klimeig_be,zone)) as detail \
             , 'ch.blw.klimaeignung-spezialkulturen' as layer \
             , quadindex(the_geom) as geom_quadindex \
             , st_y(st_transform(st_centroid(the_geom),4326)) as lat \
@@ -58,7 +58,7 @@ source src_ch_blw_klimaeignung_zwischenfruchtbau : def_searchable_features
         SELECT bgdi_id::bigint as id \
             , klimeig_be as label \
             , 'feature' as origin \
-            , remove_accents(coalesce(klimeig_be,' ')||' '||coalesce(zone,' ')) as detail \
+            , remove_accents(concat_ws(' ',klimeig_be,zone)) as detail \
             , 'ch.blw.klimaeignung-zwischenfruchtbau' as layer \
             , quadindex(the_geom) as geom_quadindex \
             , st_y(st_transform(st_centroid(the_geom),4326)) as lat \
@@ -75,7 +75,7 @@ source src_ch_blw_klimaeignung_kartoffeln : def_searchable_features
         SELECT bgdi_id::bigint as id \
             , klimeig_be as label \
             , 'feature' as origin \
-            , remove_accents(coalesce(klimeig_be,' ')||' '||coalesce(zone,' ')) as detail \
+            , remove_accents(concat_ws(' ',klimeig_be,zone)) as detail \
             , 'ch.blw.klimaeignung-kartoffeln' as layer \
             , quadindex(the_geom) as geom_quadindex \
             , st_y(st_transform(st_centroid(the_geom),4326)) as lat \
@@ -92,7 +92,7 @@ source src_ch_blw_klimaeignung_getreidebau : def_searchable_features
         SELECT bgdi_id::bigint as id \
             , klimeig_be as label \
             , 'feature' as origin \
-            , remove_accents(coalesce(klimeig_be,' ')||' '||coalesce(zone,' ')) as detail \
+            , remove_accents(concat_ws(' ',klimeig_be,zone)) as detail \
             , 'ch.blw.klimaeignung-getreidebau' as layer \
             , quadindex(the_geom) as geom_quadindex \
             , st_y(st_transform(st_centroid(the_geom),4326)) as lat \
@@ -109,7 +109,7 @@ source src_ch_blw_klimaeignung_futterbau : def_searchable_features
         SELECT bgdi_id::bigint as id \
             , klimeig_be as label \
             , 'feature' as origin \
-            , remove_accents(coalesce(klimeig_be,' ')||' '||coalesce(zone,' ')) as detail \
+            , remove_accents(concat_ws(' ',klimeig_be,zone)) as detail \
             , 'ch.blw.klimaeignung-futterbau' as layer \
             , quadindex(the_geom) as geom_quadindex \
             , st_y(st_transform(st_centroid(the_geom),4326)) as lat \
@@ -126,7 +126,7 @@ source src_ch_blw_niederschlagshaushalt : def_searchable_features
         SELECT bgdi_id::bigint as id \
             , klimeig_be as label \
             , 'feature' as origin \
-            , remove_accents(coalesce(klimeig_be,' ')||' '||coalesce(zone,' ')) as detail \
+            , remove_accents(concat_ws(' ',klimeig_be,zone)) as detail \
             , 'ch.blw.niederschlagshaushalt' as layer \
             , quadindex(the_geom) as geom_quadindex \
             , st_y(st_transform(st_centroid(the_geom),4326)) as lat \
@@ -143,7 +143,7 @@ source src_ch_blw_klimaeignung_kulturland : def_searchable_features
         SELECT bgdi_id::bigint as id \
             , klimeig_be as label \
             , 'feature' as origin \
-            , remove_accents(coalesce(klimeig_be,' ')||' '||coalesce(zone,' ')) as detail \
+            , remove_accents(concat_ws(' ',klimeig_be,zone)) as detail \
             , 'ch.blw.klimaeignung-kulturland' as layer \
             , quadindex(the_geom) as geom_quadindex \
             , st_y(st_transform(st_centroid(the_geom),4326)) as lat \
@@ -160,7 +160,7 @@ source src_ch_blw_bodeneignung_kulturtyp : def_searchable_features
         SELECT bgdi_id::bigint as id \
             , eignungsei as label \
             , 'feature' as origin \
-            , remove_accents(coalesce(farbe::text,' ')||' '||coalesce(eignungsei,' ')) as detail \
+            , remove_accents(concat_ws(' ',farbe,eignungsei)) as detail \
             , 'ch.blw.bodeneignung-kulturtyp' as layer \
             , quadindex(the_geom) as geom_quadindex \
             , st_y(st_transform(st_centroid(the_geom),4326)) as lat \
@@ -177,7 +177,7 @@ source src_ch_blw_bodeneignung_gruendigkeit : def_searchable_features
         SELECT bgdi_id::bigint as id \
             , eignungsei as label \
             , 'feature' as origin \
-            , remove_accents(coalesce(farbe::text,' ')||' '||coalesce(eignungsei,' ')) as detail \
+            , remove_accents(concat_ws(' ',farbe,eignungsei)) as detail \
             , 'ch.blw.bodeneignung-gruendigkeit' as layer \
             , quadindex(the_geom) as geom_quadindex \
             , st_y(st_transform(st_centroid(the_geom),4326)) as lat \
@@ -194,7 +194,7 @@ source src_ch_blw_bodeneignung_skelettgehalt : def_searchable_features
         SELECT bgdi_id::bigint as id \
             , eignungsei as label \
             , 'feature' as origin \
-            , remove_accents(coalesce(farbe::text,' ')||' '||coalesce(eignungsei,' ')) as detail \
+            , remove_accents(concat_ws(' ',farbe,eignungsei)) as detail \
             , 'ch.blw.bodeneignung-skelettgehalt' as layer \
             , quadindex(the_geom) as geom_quadindex \
             , st_y(st_transform(st_centroid(the_geom),4326)) as lat \
@@ -211,7 +211,7 @@ source src_ch_blw_bodeneignung_wasserspeichervermoegen : def_searchable_features
         SELECT bgdi_id::bigint as id \
             , eignungsei as label \
             , 'feature' as origin \
-            , remove_accents(coalesce(farbe::text,' ')||' '||coalesce(eignungsei,' ')) as detail \
+            , remove_accents(concat_ws(' ',farbe,eignungsei)) as detail \
             , 'ch.blw.bodeneignung-wasserspeichervermoegen' as layer \
             , quadindex(the_geom) as geom_quadindex \
             , st_y(st_transform(st_centroid(the_geom),4326)) as lat \
@@ -228,7 +228,7 @@ source src_ch_blw_bodeneignung_naehrstoffspeichervermoegen : def_searchable_feat
         SELECT bgdi_id::bigint as id \
             , eignungsei as label \
             , 'feature' as origin \
-            , remove_accents(coalesce(farbe::text,' ')||' '||coalesce(eignungsei,' ')) as detail \
+            , remove_accents(concat_ws(' ',farbe,eignungsei)) as detail \
             , 'ch.blw.bodeneignung-naehrstoffspeichervermoegen' as layer \
             , quadindex(the_geom) as geom_quadindex \
             , st_y(st_transform(st_centroid(the_geom),4326)) as lat \
@@ -245,7 +245,7 @@ source src_ch_blw_bodeneignung_wasserdurchlaessigkeit : def_searchable_features
         SELECT bgdi_id::bigint as id \
             , eignungsei as label \
             , 'feature' as origin \
-            , remove_accents(coalesce(farbe::text,' ')||' '||coalesce(eignungsei,' ')) as detail \
+            , remove_accents(concat_ws(' ',farbe,eignungsei)) as detail \
             , 'ch.blw.bodeneignung-wasserdurchlaessigkeit' as layer \
             , quadindex(the_geom) as geom_quadindex \
             , st_y(st_transform(st_centroid(the_geom),4326)) as lat \
@@ -262,7 +262,7 @@ source src_ch_blw_bodeneignung_vernaessung : def_searchable_features
         SELECT bgdi_id::bigint as id \
             , eignungsei as label \
             , 'feature' as origin \
-            , remove_accents(coalesce(farbe::text,' ')||' '||coalesce(eignungsei,' ')) as detail \
+            , remove_accents(concat_ws(' ',farbe,eignungsei)) as detail \
             , 'ch.blw.bodeneignung-vernaessung' as layer \
             , quadindex(the_geom) as geom_quadindex \
             , st_y(st_transform(st_centroid(the_geom),4326)) as lat \
@@ -279,7 +279,7 @@ source src_ch_blw_bodeneignung_kulturland : def_searchable_features
         SELECT bgdi_id::bigint as id \
             , eignungsei as label \
             , 'feature' as origin \
-            , remove_accents(coalesce(farbe::text,' ')||' '||coalesce(eignungsei,' ')) as detail \
+            , remove_accents(concat_ws(' ',farbe,eignungsei)) as detail \
             , 'ch.blw.bodeneignung-kulturland' as layer \
             , quadindex(the_geom) as geom_quadindex \
             , st_y(st_transform(st_centroid(the_geom),4326)) as lat \


### PR DESCRIPTION
Create index config for layer blw.klimaeignung and blw.bodeneignung
Rq : each layer ch.blw.klimaeignung* use the same table (blw.klimaeignung) the same for layer ch.blw.bodeneignung (blw.bodeneignung)

Tests 
python test/test.py -i ch_blw_klimaeignung_typ -e 'Futterbau'
python test/test.py -i ch_blw_klimaeignung_koernermais -e 'Futterbau'
python test/test.py -i ch_blw_klimaeignung_spezialkulturen -e 'Futterbau'
python test/test.py -i ch_blw_klimaeignung_zwischenfruchtbau -e 'Futterbau'
python test/test.py -i ch_blw_klimaeignung_kartoffeln -e 'Futterbau'
python test/test.py -i ch_blw_klimaeignung_getreidebau -e 'Futterbau'
python test/test.py -i ch_blw_klimaeignung_futterbau -e 'Futterbau'
python test/test.py -i ch_blw_klimaeignung_kulturland -e 'Futterbau'
python test/test.py -i ch_blw_niederschlagshaushalt -e 'Futterbau'
python test/test.py -i ch_blw_bodeneignung_kulturtyp -e 'Acker'
python test/test.py -i ch_blw_bodeneignung_gruendigkeit -e 'Acker'
python test/test.py -i ch_blw_bodeneignung_skelettgehalt -e 'Acker'
python test/test.py -i ch_blw_bodeneignung_wasserspeichervermoegen -e 'Acker'
python test/test.py -i ch_blw_bodeneignung_naehrstoffspeichervermoegen -e 'Acker'
python test/test.py -i ch_blw_bodeneignung_wasserdurchlaessigkeit -e 'Acker'
python test/test.py -i ch_blw_bodeneignung_vernaessung -e 'Acker'
python test/test.py -i ch_blw_bodeneignung_kulturland -e 'Acker'