### PR TITLE
add zoomlevel attribute to some swisssearch indices

### DIFF
--- a/conf/search.conf.part
+++ b/conf/search.conf.part
@@ -4,6 +4,7 @@ source src_swisssearch : def_pqsql
 {
     sql_attr_uint = num
     sql_attr_uint = rank
+    sql_attr_uint = zoomlevel
     sql_attr_string = label
     sql_attr_string = feature_id
     sql_attr_string = origin
@@ -33,6 +34,7 @@ source src_address : src_swisssearch
         , st_y(st_transform(the_geom,4326)) as lat \
         , st_x(st_transform(the_geom,4326)) as lon \
         , num \
+        , 10 as zoomlevel \
         FROM bfs.adressen_sphinx
 }
 
@@ -53,6 +55,7 @@ source src_parcel : src_swisssearch
         , st_y(st_transform(st_centroid(the_geom),4326)) as lat \
         , st_x(st_transform(st_centroid(the_geom),4326)) as lon \
         , num \
+        , 10 as zoomlevel \
         from kantone.parzellen_sphinx
 }
 
@@ -76,6 +79,7 @@ source src_swissnames3d : src_swisssearch
         , st_y(st_transform(st_geometryn(the_geom,1),4326)) as lat \
         , st_x(st_transform(st_geometryn(the_geom,1),4326)) as lon \
         , 1 as num \
+        , 9 as zoomlevel \
         , objektart \
         FROM tlm.swissnames3d_point \
         UNION ALL \
@@ -91,6 +95,7 @@ source src_swissnames3d : src_swisssearch
         , st_y(st_transform(st_ClosestPoint(the_geom,st_centroid(the_geom)),4326)) as lat \
         , st_x(st_transform(st_ClosestPoint(the_geom,st_centroid(the_geom)),4326)) as lon \
         , 1 as num \
+        , 9 as zoomlevel \
         , objektart \
         FROM tlm.swissnames3d_line \
         UNION ALL \
@@ -106,6 +111,7 @@ source src_swissnames3d : src_swisssearch
         , st_y(st_transform(st_ClosestPoint(the_geom,st_centroid(the_geom)),4326)) as lat \
         , st_x(st_transform(st_ClosestPoint(the_geom,st_centroid(the_geom)),4326)) as lon \
         , 1 as num \
+        , 9 as zoomlevel \
         , objektart \
         FROM tlm.swissnames3d_poly \
         ) sub \
@@ -124,6 +130,7 @@ source src_swissnames3d : src_swisssearch
         , st_y(st_transform(st_geometryn(the_geom,1),4326)) as lat \
         , st_x(st_transform(st_geometryn(the_geom,1),4326)) as lon \
         , 1 as num \
+        , 10 as zoomlevel \
         , objektart \
         FROM tlm.swissnames3d_dkm10_blacklist \
     ) \
@@ -141,7 +148,8 @@ source src_swissnames3d : src_swisssearch
         coalesce(b.y,s.y) as y, \
         coalesce(b.lat,s.lat) as lat, \
         coalesce(b.lon,s.lon) as lon, \
-        1 as num \
+        1 as num, \
+        coalesce(b.zoomlevel,s.zoomlevel) as zoomlevel \
     FROM swissnames s \
     left outer join dkm b ON s.feature_id = b.feature_id \
     UNION ALL \
@@ -157,7 +165,8 @@ source src_swissnames3d : src_swisssearch
         b.y as y, \
         b.lat as lat, \
         b.lon as lon, \
-        1 as num \
+        1 as num, \
+        b.zoomlevel \
     FROM swissnames s \
     inner join dkm b on s.name = b.name and s.objektklasse = 'TLM_GEBAEUDE' and s.feature_id <> b.feature_id \
     ) s


### PR DESCRIPTION
This pr adds a new attribute to the following partial indices of swissearch:
address -> zoomlevel 10  [1]
parcel -> zoomlevel 10  [1]
swissnames3d/gazetteer -> zoomlevel 9 for everything except dkm, zoomlevel 10 for dkm [2]

How will we treat the swisssearch indices without this zoomlevel information?
zoomlevel = NULL
no zoomlevel attribute (see this pr)
zoomlevel = 0

[1] https://github.com/geoadmin/mf-geoadmin3/blob/febce145bef4d99956132a3a6ac6371fd5c848c8/src/components/search/SearchTypesDirectives.js#L16

[2] https://github.com/geoadmin/mf-geoadmin3/issues/3394
