### PR TITLE
add new ranking for gazetteer.haltestellen

### DIFF
--- a/conf/search.conf.part
+++ b/conf/search.conf.part
@@ -27,7 +27,7 @@ source src_address : src_swisssearch
         , origin \
         , bgdi_quadindex as geom_quadindex \
         , geom_st_box2d \
-        , 6::integer as rank \
+        , 7::integer as rank \
         , x \
         , y \
         , st_y(st_transform(the_geom,4326)) as lat \
@@ -260,7 +260,7 @@ source src_haltestellen : src_swisssearch
         , 'gazetteer'::text as origin \
         , quadindex(the_geom) as geom_quadindex \
         , box2d(the_geom) as geom_st_box2d \
-        , 5::integer as rank \
+        , 6::integer as rank \
         , st_y((st_geometryn(the_geom,1))) as x \
         , st_x((st_geometryn(the_geom,1))) as y \
         , st_y(st_transform(st_geometryn(the_geom,1),4326)) as lat \

--- a/conf/search.conf.part
+++ b/conf/search.conf.part
@@ -27,7 +27,7 @@ source src_address : src_swisssearch
         , origin \
         , bgdi_quadindex as geom_quadindex \
         , geom_st_box2d \
-        , 7::integer as rank \
+        , 6::integer as rank \
         , x \
         , y \
         , st_y(st_transform(the_geom,4326)) as lat \
@@ -260,7 +260,7 @@ source src_haltestellen : src_swisssearch
         , 'gazetteer'::text as origin \
         , quadindex(the_geom) as geom_quadindex \
         , box2d(the_geom) as geom_st_box2d \
-        , 6::integer as rank \
+        , 7::integer as rank \
         , st_y((st_geometryn(the_geom,1))) as x \
         , st_x((st_geometryn(the_geom,1))) as y \
         , st_y(st_transform(st_geometryn(the_geom,1),4326)) as lat \


### PR DESCRIPTION
this pr will add a new rank for haltestellen within the gazetteer index.
This will allow us to do a better ranking of the gazetteer results.

the affected indices can be build with:
```bash
$ time indexer --verbose --rotate --sighup-each --config conf/sphinx.conf address address_metaphone haltestellen haltestellen_metaphone
```

the rank has been changed from

| rank | source    |
|------|-----------|
| 1    | zipcode   |
| 2    | gg25      |
| 3    | district  |
| 4    | kanton    |
| 5    | gazetteer (swissnames,dkm10,haltestellen) |
| 6    | address   |
| 7    | not used  |
| 8    | not used  |
| 9    | not used  |
| 10   | parcel    |

to

| rank | source    |
|------|-----------|
| 1    | zipcode   |
| 2    | gg25      |
| 3    | district  |
| 4    | kanton    |
| 5    | gazetteer (swissnames,dkm10) |
| **6**    | **gazetteer (haltestellen)**  |
| **7**    | **address** |
| 8    | not used  |
| 9    | not used  |
| 10   | parcel    |