### PR TITLE
Test only SQL of syncronized layers on deploy table

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,16 +11,16 @@ help:
 	@echo
 	@echo "Indexing only for updates (sudo su sphinxsearch):"
 	@echo
-	@echo "- index-all	           Update all indices (does NOT re-create config file)"
-	@echo "- index-grep	           Update indices that match a given pattern. Pass the pattern as IPATTERN=mypattern directly on the commandline"
-	@echo "- index-search	           Update swisssearch indices (does NOT re-create config file)"
-	@echo "- index-layer	           Update all the layers indices (does NOT re-create config file)"
-	@echo "- index-feature	           Update all the features indices (does NOT re-create config file)"
-	@echo "- move-template	           Move template to the apropriate locations"
+	@echo "- index-all                 Update all indices (does NOT re-create config file)"
+	@echo "- index-grep                Update indices that match a given pattern. Pass the pattern as IPATTERN=mypattern directly on the commandline"
+	@echo "- index-search              Update swisssearch indices (does NOT re-create config file)"
+	@echo "- index-layer               Update all the layers indices (does NOT re-create config file)"
+	@echo "- index-feature             Update all the features indices (does NOT re-create config file)"
+	@echo "- move-template             Move template to the apropriate locations and tests all sql queries"
 	@echo
 	@echo "Generate configuration template:"
 	@echo
-	@echo "- template	           Create sphinx config file from template"
+	@echo "- template                  Create sphinx config file from template"
 	@echo
 	@echo "Deploy:"
 	@echo
@@ -87,7 +87,7 @@ deploy-demo:
 
 .PHONY: deploy-int-clean_index
 deploy-int-clean_index:
-	cd deploy && bash deploy-conf-only.sh -t int -c true 
+	cd deploy && bash deploy-conf-only.sh -t int -c true
 
 .PHONY: deploy-prod-clean_index
 deploy-prod-clean_index:
@@ -104,7 +104,7 @@ ifneq ($(db),)
 else ifneq ($(index),)
 		cd deploy && bash deploy-conf-only.sh -t int -i $(index)
 else
-		cd deploy && bash deploy-conf-only.sh -t int 
+		cd deploy && bash deploy-conf-only.sh -t int
 endif
 
 .PHONY: deploy-prod-config

--- a/deploy/deploy-conf-only.sh
+++ b/deploy/deploy-conf-only.sh
@@ -8,26 +8,26 @@ deploy-conf-only.sh
 sphinx deploy wrapper script
 Deploys the sphinx config to the target, if the optional parameter -d is set, all the index using the defined database pattern will be built.
 arguments:
-    -t <<DEPLOY TARGET>> mandatory 
+    -t <<DEPLOY TARGET>> mandatory
         p.e.
         -t int
         -t prod
-    -d <<DATABASE PATTERN>> optional 
-        p.e. 
+    -d <<DATABASE PATTERN>> optional
+        p.e.
         -d lubis_prod -> all indexes using this database will be built
         -d stopo_prod.public -> all indexes using a table from that schema will be built
         -d bafu_prod.gefahren.gfz -> all indexes using this table will be built
         -d all -> all the indexes will be built
         DEFAULT: none
-    -i <<INDEX PATTERN>> optional 
-        p.e. 
+    -i <<INDEX PATTERN>> optional
+        p.e.
         -i ch_swisstopo -> all indexes with infix ***ch_swisstopo*** will be built
         -i all -> all the indexes will be built
-        DEFAULT: none        
+        DEFAULT: none
     -c  <<CLEAN INDEX>> [true|false] optional
         p.e.
         -c true -> on the deploy target missing indexes will be created, orphaned indexes will be deleted
-        DEFAULT: false 
+        DEFAULT: false
         "
 
 if [ ! -f $SPHINXCONFIG ]
@@ -60,7 +60,7 @@ do
 done
 shift $((OPTIND-1))
 
-if [ ! $t_flag ] 
+if [ ! $t_flag ]
 then
     echo "$usage"
     exit 0

--- a/deploy/pg2sphinx_trigger.py
+++ b/deploy/pg2sphinx_trigger.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-# 
+#
 # read sphinx config file and update all indexes related to input database or input table or index pattern
 
 import os
@@ -15,11 +15,11 @@ import subprocess
 from optparse import OptionParser
 
 
-def pg_get_tables(sql_query,sql_db):
+def pg_get_tables(sql_query, sql_db):
     # add 'EXPLAIN VERBOSE ' to sql string
     sql_query = 'EXPLAIN VERBOSE ' + sql_query
 
-    conn_string = "host='%s' dbname='%s' user='%s' password='%s'" % (CONN_HOST,sql_db,CONN_USER,CONN_PWD)
+    conn_string = "host='%s' dbname='%s' user='%s' password='%s'" % (CONN_HOST, sql_db, CONN_USER, CONN_PWD)
     # get a connection, if a connect cannot be made an exception will be raised here
     conn = psycopg2.connect(conn_string)
     # conn.cursor will return a cursor object, you can use this cursor to perform queries
@@ -32,7 +32,7 @@ def pg_get_tables(sql_query,sql_db):
     for i in records:
         table = re.search('[Bitmap Heap|Index|Seq] Scan.* on ([^ ]+)', i[0])
         table = table.group(1) if table else None
-        if table and not 'Bitmap Index Scan' in i[0]: 
+        if table and not 'Bitmap Index Scan' in i[0]:
             t.append(sql_db+'.'+table)
             #print "linie: '%s' -> extract: '%s'" % (i[0],table)
     t = list(set(t)) # get rid of duplicate entries in the list and sorting
@@ -72,10 +72,30 @@ if __name__ == '__main__':
 
     OptionParser.format_epilog = lambda self, formatter: self.epilog
     parser = OptionParser(epilog=epilog)
-    parser.add_option("-d","--database_filter", dest="database_filter", default=None, action="store", help="Database Filter: optional database prefix")
-    parser.add_option("-i","--index_filter", dest="index_filter", default=None, action="store", help="Index Filter: optional index prefix")
-    parser.add_option("-c","--command", dest="command", default="list", action="store", help="-c list: will list all the indexes touched by the database filter\n-c update: will update all the indexes touched by the database filter.")
-    parser.add_option("-s","--sphinxconf", dest="config", default=SPHINXCONFIG, action="store", help="-s /path/to/sphinx/sphinx.conf")
+    parser.add_option("-d",
+                      "--database_filter",
+                      dest="database_filter",
+                      default=None,
+                      action="store",
+                      help="Database Filter: optional database prefix")
+    parser.add_option("-i",
+                      "--index_filter",
+                      dest="index_filter",
+                      default=None,
+                      action="store",
+                      help="Index Filter: optional index prefix")
+    parser.add_option("-c",
+                      "--command",
+                      dest="command",
+                      default="list",
+                      action="store",
+                      help="-c list: will list all the indexes touched by the database filter\n-c update: will update all the indexes touched by the database filter.")
+    parser.add_option("-s",
+                      "--sphinxconf",
+                      dest="config",
+                      default=SPHINXCONFIG,
+                      action="store",
+                      help="-s /path/to/sphinx/sphinx.conf")
     (options, args) = parser.parse_args()
 
     # Some initial tests
@@ -86,7 +106,7 @@ if __name__ == '__main__':
         sys.exit("ERROR: Sphinx config file doesn't exist: %s" % options.config)
 
     # -c --command
-    if options.command not in ['list','update']:
+    if options.command not in ['list', 'update']:
         parser.print_help()
         sys.exit( 1 )
 
@@ -98,7 +118,7 @@ if __name__ == '__main__':
     filter_option = ""
     if options.database_filter:
         filter_option='database'
-        
+
     if options.index_filter:
         filter_option='index'
 
@@ -106,23 +126,23 @@ if __name__ == '__main__':
          SPHINXCONFIG=options.config
 
 
-    # SQLITE Initialize and create tables in memory    
+    # SQLITE Initialize and create tables in memory
     conn = sqlite3.connect(":memory:")
     c = conn.cursor()
     c.execute("""
-                create table sources (
+                CREATE TABLE sources (
                     id INTEGER PRIMARY KEY
                     , source text
                     , source_parent text
                     , sql_db text
                     , sql_query text
-                    , indexes 
+                    , indexes
                     text
                     );
                     """)
 
     c.execute("""
-                create table indexes (
+                CREATE TABLE indexes (
                     id INTEGER PRIMARY KEY
                     , sphinx_index text
                     , index_parent
@@ -143,7 +163,7 @@ if __name__ == '__main__':
     CONN_PORT=re.findall('sql_port\s*=\s*(.*)', data)[0]
 
     # parse sphinx config sources and write them to sqlite sources table ...
-    # TODO: 
+    # TODO:
     # regex which can extract source, sql_db and sql_query in one step
     # step 1 extract source and content in curly braces
     reg_source = re.compile(r'''
@@ -172,11 +192,11 @@ if __name__ == '__main__':
                         , source_parent
                         , sql_db
                         , sql_query
-                        ) 
+                        )
                         VALUES  (? ,?, ?, ?);""" ,(source.strip(), str(source_parent).strip(), sql_db, sql_query))
 
     # parse sphinx config indexes and write them to sqlite indexes table ...
-    # TODO: 
+    # TODO:
     # regex which can extract source, sql_db and sql_query in one step
     # step 1 extract source and content in curly braces
     reg_index = re.compile(r'''
@@ -186,7 +206,7 @@ if __name__ == '__main__':
             .*?                                 # Next part:
             (?P<content> (?<={)[^}]*(?=}))      # catch everything but curly braces
         ''', re.MULTILINE | re.DOTALL | re.VERBOSE | re.UNICODE)
-    
+
     # get distributed indices first
     distributed_index = {}
     for i in reg_index.finditer(data):
@@ -196,8 +216,8 @@ if __name__ == '__main__':
         index_type = index_type.group(1).strip() if index_type else None
         index_local = re.findall('local\s=\s*(.*)', i.groupdict()['content'])
         index_local = index_local if index_local else None
-        if index_local:    
-            distributed_index[index]=index_local
+        if index_local:
+            distributed_index[index] = index_local
 
     for i in reg_index.finditer(data):
         index, index_parent = parsing_func(i.groupdict()['index'])
@@ -215,24 +235,39 @@ if __name__ == '__main__':
                         INSERT INTO indexes (
                             sphinx_index
                             , index_parent
-                            ,source
+                            , source
                             ) VALUES(?, ?, ?);""" ,(index.strip(), str(index_parent).strip(), source))
 
     # output
     sql = """
-        select
+        SELECT
             a.source as source
-            , coalesce(a.sql_db,b.sql_db) as database
+            , coalesce(a.sql_db, b.sql_db) as database
             , a.sql_query as sql
             , i.sphinx_index
             , i.index_parent
-            FROM 
-            indexes i left join indexes p on trim(i.index_parent)=trim(p.sphinx_index)
-            left join sources a on coalesce(i.source,p.source) = a.source
-            left join sources b on a.source_parent = b.source
+            FROM
+            indexes i LEFT JOIN indexes p on trim(i.index_parent) = trim(p.sphinx_index)
+            LEFT JOIN sources a on coalesce(i.source, p.source) = a.source
+            LEFT JOIN sources b on a.source_parent = b.source
     """
-    
-    resultat=[]
+
+    tables_target = []
+    db_path = options.database_filter.split('.')
+    is_table_target = bool(re.match('^[a-z]+_(dev|int|prod)\.[a-z|_|0-9]+\.[a-z|_|0-9]+$', options.database_filter))
+    if is_table_target:
+        sql_target = 'SELECT * FROM %s.%s' % (db_path[1], db_path[2])
+        try:
+            tables_target = pg_get_tables(sql_target, db_path[0])
+            tables_target = tables_target.split(',')
+        except Exception as e:
+            msg = 'Error while analysing table deps\n'
+            msg += 'SQL: %s\n%s' % (sql, e)
+            raise Exception(e)
+        # Add initial view to the list
+        if options.database_filter not in tables_target:
+            tables_target.append(options.database_filter)
+    results=[]
     for row in c.execute(sql):
         db = None
         indices = row['sphinx_index']
@@ -240,47 +275,66 @@ if __name__ == '__main__':
         # database filter
         # -d pattern
         if options.index_filter is None:
-            if (options.database_filter and options.database_filter.count('.')==0) or (options.database_filter == None):
+            if (options.database_filter and len(db_path) == 0) or (options.database_filter == None):
                 # db only filter can be applied to sphinx config, no need to query postgres db
                 if options.database_filter is None or options.database_filter == row['database']:
                     db = row['database']
                 # if db filter is more detailed, we have to analyze the sql queries with postgres ANALZYE VERBOSE
-            elif options.database_filter.split(".")[0] == row['database']:
-                table =  pg_get_tables(row['sql'], row['database'])
-                db = row['database'] if options.database_filter in table else None
+            elif db_path[0] == row['database']:
+                # In case the taget is table, only the SQL related to the target table for sphinx rotation indices
+                if is_table_target:
+                    tables = []
+                    if len([t for t in tables_target if t.replace('%s.' % row['database'], '') in row['sql']]) > 0:
+                        table_path = '%s.%s' % (db_path[1], db_path[2])
+                        try:
+                            tables =  pg_get_tables(row['sql'], row['database'])
+                        except Exception as e:
+                            msg = 'SQL query not valid for table %s\n' % table_path
+                            msg += 'Trying to evaluate the following query:\n'
+                            msg += '%s\n' % row['sql']
+                            msg += 'Error:\n%s' % e
+                            raise Exception(msg)
+                        # we're dealing with a view
+                        if options.database_filter not in tables:
+                            tables += ',%s' % options.database_filter
+                # Otherwise try all sql queries and bail out on any error
+                else:
+                    try:
+                        tables =  pg_get_tables(row['sql'], row['database'])
+                    except Exception as e:
+                        msg = 'Trying to evaluate the following query:\n'
+                        msg += '%s\n' % row['sql']
+                        msg += 'Error:\n%s' % e
+                        raise Exception(msg)
+                db = row['database'] if options.database_filter in tables else None
         # indice filter
         # -i pattern
         else:
-            if options.index_filter in indices or options.index_filter == 'all' or options.index_filter in indices_distributed :
+            if options.index_filter in indices or options.index_filter == 'all' or options.index_filter in indices_distributed:
                 db = row['database']
 
-        # output  
+        # output
         if options.command == 'list' and db is not None:
-            resultat.append("%s -> %s" % (indices, db))
+            results.append("%s -> %s" % (indices, db))
 
         if options.command == 'update' and db is not None:
-            resultat.append("%s" % (indices))
+            results.append("%s" % (indices))
 
-    resultat = sorted(list(set(resultat))) # get rid of duplicate entries in the list and sorting   
-    indent="\n      "     
+    results = sorted(list(set(results))) # get rid of duplicate entries in the list and sorting
+    indent="\n      "
     if options.command == 'list':
-        if resultat:
-            print "%s indexes are using the %s pattern: %s%s%s" % (len(resultat), filter_option, options.database_filter or options.index_filter,indent,indent.join(resultat))
+        if results:
+            print "%s indexes are using the %s pattern: %s%s%s" % (len(results), filter_option, options.database_filter or options.index_filter, indent, indent.join(results))
         else:
             print "no indexes are using the %s pattern: %s" % (filter_option, options.database_filter or options.index_filter)
     elif options.command == 'update':
-        if resultat:
-            sphinx_command = 'indexer --config %s --verbose --rotate --sighup-each %s' % (options.config,' '.join(resultat))
+        if results:
+            sphinx_command = 'indexer --config %s --verbose --rotate --sighup-each %s' % (options.config,' '.join(results))
             print sphinx_command
             #uncomment following lines for real update
-            p = subprocess.Popen(sphinx_command,stdout=subprocess.PIPE,shell=True, env=myenv)
+            p = subprocess.Popen(sphinx_command, stdout=subprocess.PIPE, shell=True, env=myenv)
             for line in iter(p.stdout.readline, ''):
                 print line.strip()
             p.stdout.close()
-            
         else:
             print 'no sphinx indexes are using the %s pattern %s' % (filter_option, options.database_filter or options.index_filter)
-
-#
-# $Id$
-#


### PR DESCRIPTION
At the moment the problem is as follow:

- When we deploy the databases, we first deploy the configuration and then the dbs which trigger a rotation of sphinx indices. At this point usually everything is up to date.

- Now, we sometimes also make partial updates. The config would work in dev or int so we merge it, but we don't want to deploy the whole database, because either we can't for political reasons or because the layer is only in dev (and we need them to be in the config as we control the presence of these indices in chsdi for layers in `dev` staging). At the moment our sphinxconfig is not staging dependant but our DBs are.

- By design the `sphinx trigger` (see in https://github.com/geoadmin/service-sphinxsearch/blob/master/deploy/hooks_conf_only/post-restore-code) will syncronize the indices based on db pattern or an index prefix and it will fail to rotate indices if it finds **any** sql in the configuration that doesn't work with the productive database.

With this PR we ensure that only the sql related to the table is tested. I don't think this is the best design, but it is the design that will ensure that our sphinx indices are always up to date and won't fail to rotate because of some layers that have not reached production yet.

Note: that having a non-valid SQL query on prod will not impact the indexer if not called directly.

This is linked to https://github.com/geoadmin/service-sphinxsearch/issues/297

