### PR TITLE
update search for bav.schienen_*

### DIFF
--- a/conf/uvek.conf.part
+++ b/conf/uvek.conf.part
@@ -29,13 +29,13 @@ source src_ch_bav_schienennetz : def_searchable_features
             SELECT \
                  nom_segment as label \
                 , 'feature' as origin \
-                , remove_accents(coalesce(nom_segment, ' ')) as detail \
+                , remove_accents(concat_ws(' ', xtf_id_tooltip, nom_segment, kmtext, kmnumero, abreviationet)) as detail \
                 , 'ch.bav.schienennetz' as layer \
                 , quadindex(the_geom) as geom_quadindex \
                 , st_y(st_transform(st_ClosestPoint(the_geom,st_centroid(the_geom)),4326)) as lat \
                 , st_x(st_transform(st_ClosestPoint(the_geom,st_centroid(the_geom)),4326)) as lon \
                 , box2d(the_geom) as geom_st_box2d \
-                , bgdi_id::text as feature_id \
+                , id::text as feature_id \
             from bav.schienennetz_segment \
             ) sub
 }


### PR DESCRIPTION
More attributes in search, as more are being displayed in [tooltip](https://mf-geoadmin3.dev.bgdi.ch/?api_url=%2F%2Fmf-chsdi3.dev.bgdi.ch%2Fltrea_bav_eisenbahn_strecke&lang=de&topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen,ch.bfs.gebaeude_wohnungs_register,ch.bav.haltestellen-oev,ch.swisstopo.swisstlm3d-wanderwege,ch.bav.schienennetz&layers_visibility=false,false,false,false,true&layers_timestamp=18641231,,,,&X=215750.00&Y=644000.00&zoom=5).