### PR TITLE
pg-sandbox.bgdi.ch elb will not be stable anymore, snapshotter instance

### DIFF
--- a/conf/db.conf.in
+++ b/conf/db.conf.in
@@ -3,7 +3,7 @@
 source def_pqsql
 {
     type = pgsql
-    sql_host = pg-sandbox.bgdi.ch
+    sql_host = pg.bgdi.ch
     sql_user = $PGUSER
     sql_pass = $PGPASS
     sql_port = 5432


### PR DESCRIPTION
can be offline for 1 hour or more, that's why we are using the
production elb now for sphinx queries