### PR TITLE
Remove old test indices historische namen

### DIFF
--- a/conf/stopo.conf.part
+++ b/conf/stopo.conf.part
@@ -1,37 +1,5 @@
 ## SOURCES
 
-source src_ch_kantone_historische-topografische-namen : def_pqsql
-{
-    sql_db = stopo_dev
-    sql_attr_string = ids
-    sql_attr_string = synonyms
-    sql_attr_string = years
-    sql_attr_string = feature_id
-    sql_attr_string = origin
-    sql_attr_string = layer
-    sql_attr_string = geom_st_box2d
-    sql_attr_string = label
-    sql_attr_float = lat
-    sql_attr_float = lon
-    sql_field_string = geom_quadindex
-    sql_field_string = detail
-    sql_query = \
-        SELECT id as id \
-            , origin as origin \
-            , detail as detail \
-            , layer as layer \
-            , geom_quadindex as geom_quadindex \
-            , lat as lat \
-            , lon as lon \
-            , geom_st_box2d as geom_st_box2d \
-            , label as label \
-            , feature_id as feature_id \
-            , ids as ids\
-            , synonyms as synonyms \
-            , years as years \
-        FROM public.historische_topo_namen_sphinx_view
-}
-
 source src_ch_swisstopo_swissboundaries3d-bezirk-flaeche_fill : def_searchable_features
 {
     sql_db = stopo_dev
@@ -921,12 +889,6 @@ index ch_swisstopo_landesschwerenetz : ch_swisstopo_verschiebungsvektoren-tsp1
 {
     source = src_ch_swisstopo_landesschwerenetz
     path = /var/lib/sphinxsearch/data/index/ch_swisstopo_landesschwerenetz
-}
-
-index ch_kantone_historische-topografische-namen : ch_swisstopo_verschiebungsvektoren-tsp1
-{
-    source = src_ch_kantone_historische-topografische-namen
-    path = /var/lib/sphinxsearch/data/index/ch_kantone_historische-topografische-namen
 }
 
 index ch_swisstopo_verschiebungsvektoren-tsp2 : ch_swisstopo_verschiebungsvektoren-tsp1


### PR DESCRIPTION
ping @ltclm 

Because we'll never use these indices and project is dead, we removed the table and view containing this data.
See: https://github.com/geoadmin/tool-wms/pull/52