### PR TITLE
tlm.dkm_search has prioriy over tlm.swissnames_* 

### DIFF
--- a/conf/search.conf.part
+++ b/conf/search.conf.part
@@ -156,7 +156,7 @@ source src_swissnames3d : src_swisssearch
         ) sub \
         WHERE  objektart not like 'Haltestelle%' \
     ) \
-    select row_number() OVER(ORDER BY 1 asc) as id , * FROM \
+    select distinct on (feature_id) row_number() OVER(ORDER BY 1 asc) as id , * FROM \
         ( \
     SELECT \
         coalesce(b.feature_id,s.feature_id) as feature_id, \


### PR DESCRIPTION
that's why we have to hide duplicates in the query

fixes https://github.com/geoadmin/mf-geoadmin3/issues/3941

Index has been updated on dev [environment](https://mf-geoadmin3.dev.bgdi.ch/?lang=de&topic=ech&bgLayer=ch.swisstopo.pixelkarte-farbe&layers=ch.swisstopo.zeitreihen,ch.bfs.gebaeude_wohnungs_register,ch.bav.haltestellen-oev,ch.swisstopo.swisstlm3d-wanderwege&layers_visibility=false,false,false,false&layers_timestamp=18641231,,,)

search for 
```
schliern
biancograt
igl crap
kw fiesch
albumo apriasca
```
