### PR TITLE
reorder db usage

### DIFF
--- a/conf/db.conf.in
+++ b/conf/db.conf.in
@@ -3,7 +3,7 @@
 source def_pqsql
 {
     type = pgsql
-    sql_host = pg.bgdi.ch
+    sql_host = pg-sandbox.bgdi.ch
     sql_user = $PGUSER
     sql_pass = $PGPASS
     sql_port = 5432

--- a/deploy/deploy.cfg
+++ b/deploy/deploy.cfg
@@ -20,6 +20,10 @@ dbsuffix_prod = _prod
 ; demo
 dbsuffix_demo = _demo
 
+dbhost_t=pg-sandbox.bgdi.ch
+dbhost_p=pg.bgdi.ch
+
+
 [remote_hosts]
 int = ip-10-220-4-39.eu-west-1.compute.internal
 prod = ip-10-220-5-210.eu-west-1.compute.internal,

--- a/deploy/hooks/post-restore-code
+++ b/deploy/hooks/post-restore-code
@@ -48,6 +48,7 @@ sudo -u sphinxsearch mv $BASEDIR/index.tmp $BASEDIR/index
 
 
 DBSUFFIX=$DBSUFFIX_DEFAULT
+DBHOST=$DBHOST_T
 # TARGET -> integration
 if [[ $TARGET == int ]]
 then
@@ -58,6 +59,7 @@ fi
 if [[ $TARGET == prod ]]
 then
   DBSUFFIX=$DBSUFFIX_PROD
+  DBHOST=$DBHOST_P
 fi
 
 # TARGET -> demo
@@ -69,6 +71,9 @@ fi
 echo "replace db suffix with $DBSUFFIX (p.e. lubis_3d_dev -> lubis_3d$DBSUFFIX)..."
 #                                       (----------$1---------)(---$3---)(-------------$4--------------)   (---$5--)
 sudo -u sphinxsearch perl -X -wi -pe 's#(sql_db[ \t]*=[ \t]*\b)(([^\W"]+)(_master|_dev|_prod|_int|_demo)\b|([^\W"]+))#$1$3$5'$DBSUFFIX'#gi' /etc/sphinxsearch/sphinx.conf
+
+echo "replace db host with ${DBHOST} ..."
+sudo -u sphinxsearch sed -i "s,pg-sandbox.bgdi.ch,${DBHOST}," /etc/sphinxsearch/sphinx.conf
 
 WAITFORSPHINX=20
 COUNTER=1


### PR DESCRIPTION
we have to patch the db deploy script too before merging this one.
db deploy script fires a dml trigger which is updating sphinx indices.
the db deploy script is currently waiting for a constistent replication state of the slaves behind pg.bgdi.ch.
We have to wait for the pg-sandbox slaves for dev and int table deploy.