### PR TITLE
use canton information from data

### DIFF
--- a/conf/search.conf.part
+++ b/conf/search.conf.part
@@ -283,7 +283,7 @@ source src_zipcode : src_swisssearch
         gid as id \
         , os_uuid::text as feature_id \
         , plz::text as detail \
-        , '<b>'||coalesce(plz::text,'')||' - '||coalesce(langtext,'')||' ('||coalesce((select array_to_string(array_agg(ak order by st_area(st_intersection(p.the_geom,k.the_geom))desc),',') FROM tlm.swissboundaries_kantone k WHERE st_intersects(p.the_geom,k.the_geom)),'')||')</b>' as label \
+        , '<b>'||coalesce(plz::text,'')||' - '||coalesce(langtext,'')||' ('||coalesce(canton,'')||')</b>' as label \
         , 'zipcode' as origin \
         , quadindex(the_geom) as geom_quadindex \
         , box2d(st_transform(the_geom, 21781)) as geom_st_box2d \


### PR DESCRIPTION
based on the discussion https://github.com/geoadmin/mf-chsdi3/issues/3007

this will replace the source of canton information in plz search results
spatial intersection will be replaced with attribute (data.geo.admin.ch > CSV)
Testlink:
https://mf-chsdi3.dev.bgdi.ch/shorten/7dfec2d7e6