### PR TITLE
use legacy index types to avoid oomkiller

### DIFF
--- a/conf/bafu.conf.part
+++ b/conf/bafu.conf.part
@@ -1051,6 +1051,7 @@ source src_ch_bafu_grundwasserkoerper : def_searchable_features
 index ch_bafu_hydrologie_wassertemperaturmessstationen
 {
     type = plain
+    dict=crc
     source = src_ch_bafu_hydrologie_wassertemperaturmessstationen
     path = /var/lib/sphinxsearch/data/index/ch_bafu_hydrologie_wassertemperaturmessstationen
     docinfo = extern

--- a/conf/bod.conf.part
+++ b/conf/bod.conf.part
@@ -108,6 +108,7 @@ source src_layers_rm : layers
 index layers
 {
     type = plain
+    dict=crc
     docinfo = extern
     min_infix_len = 2
     expand_keywords = 1

--- a/conf/dritte.conf.part
+++ b/conf/dritte.conf.part
@@ -77,6 +77,7 @@ source src_ch_sem_sachplan_asyl_kraft : def_searchable_features
 index ch_pronatura_waldreservate
 {
     type = plain
+    dict=crc
     source = src_ch_pronatura_waldreservate
     path = /var/lib/sphinxsearch/data/index/ch_pronatura_waldreservate
     docinfo = extern

--- a/conf/edi.conf.part
+++ b/conf/edi.conf.part
@@ -42,6 +42,7 @@ source src_ch_bfs_generalisierte_grenzen_agglomerationen_g2 : def_searchable_fea
 index ch_bfs_generalisierte_grenzen_agglomerationen_g1
 {
     type = plain
+    dict=crc
     source = src_ch_bfs_generalisierte_grenzen_agglomerationen_g1
     path = /var/lib/sphinxsearch/data/index/ch_bfs_generalisierte_grenzen_agglomerationen_g1
     docinfo = extern

--- a/conf/evd.conf.part
+++ b/conf/evd.conf.part
@@ -312,6 +312,7 @@ source src_ch_blw_bodeneignung_kulturland : def_searchable_features
 index ch_blw_klimaeignung_typ
 {
     type = plain
+    dict=crc
     source = src_ch_blw_klimaeignung_typ
     path = /var/lib/sphinxsearch/data/index/ch_blw_klimaeignung_typ
     docinfo = extern

--- a/conf/kogis.conf.part
+++ b/conf/kogis.conf.part
@@ -100,6 +100,7 @@ source src_ch_bfs_gebaeude_wohnungs_register : def_searchable_features
 index ch_swisstopo_fixpunkte_hfp1
 {
     type = plain
+    dict=crc
     source = src_ch_swisstopo_fixpunkte_hfp1
     path = /var/lib/sphinxsearch/data/index/ch_swisstopo_fixpunkte_hfp1
     docinfo = extern

--- a/conf/lubis.conf.part
+++ b/conf/lubis.conf.part
@@ -157,6 +157,7 @@ source src_ch_swisstopo_lubis_terrestrische_aufnahmen : def_searchable_features_
 index ch_swisstopo_lubis_bildstreifen
 {
     type = plain
+    dict=crc
     source = src_ch_swisstopo_lubis_bildstreifen
     path = /var/lib/sphinxsearch/data/index/ch_swisstopo_lubis_bildstreifen
     docinfo = extern

--- a/conf/stopo.conf.part
+++ b/conf/stopo.conf.part
@@ -1110,6 +1110,7 @@ source src_ch_swisstopo_swiss_map_vector25_metadata : def_searchable_features
 index ch_swisstopo_verschiebungsvektoren_tsp1
 {
     type = plain
+    dict=crc
     source = src_ch_swisstopo_verschiebungsvektoren_tsp1
     path = /var/lib/sphinxsearch/data/index/ch_swisstopo_verschiebungsvektoren_tsp1
     docinfo = extern

--- a/conf/uvek.conf.part
+++ b/conf/uvek.conf.part
@@ -1422,6 +1422,7 @@ source src_ch_bav_anlagen_schienengueterverkehr : def_searchable_features
 index ch_astra_ivs_nat
 {
     type = plain
+    dict=crc
     source = src_ch_astra_ivs_nat
     path = /var/lib/sphinxsearch/data/index/ch_astra_ivs_nat
     docinfo = extern

--- a/conf/vbs.conf.part
+++ b/conf/vbs.conf.part
@@ -113,6 +113,7 @@ source src_ch_vbs_retablierungsstellen : def_searchable_features
 index ch_babs_kulturgueter
 {
     type = plain
+    dict=crc
     source = src_ch_babs_kulturgueter
     path = /var/lib/sphinxsearch/data/index/ch_babs_kulturgueter
     docinfo = extern


### PR DESCRIPTION
We have to use the legacy index type crc to avoid oom killer.