### PR TITLE
change parcel data source

### DIFF
--- a/conf/search.conf.part
+++ b/conf/search.conf.part
@@ -46,7 +46,7 @@ source src_address : src_swisssearch
 
 source src_parcel : src_swisssearch
 {
-    sql_db=dritte_dev
+    sql_db=stopo_dev
     sql_query = \
         SELECT id \
         , NULL::text as feature_id \
@@ -65,7 +65,7 @@ source src_parcel : src_swisssearch
         , st_x(st_transform(st_centroid(the_geom),4326)) as lon \
         , num \
         , 10 as zoomlevel \
-        from kantone.parzellen_sphinx
+        from vd.parzellen_sphinx
 }
 
 source src_swissnames3d : src_swisssearch


### PR DESCRIPTION

old sphinx input vs new sphinx input
```SQL
stopo_master=> select id, detail, label, origin, geom_st_box2d, num, egris_egrid, x, y, st_asewkt(the_geom) FROM vd.parzellen_sphinx  where egris_egrid = 'ch470171978501' limit 1;
-[ RECORD 1 ]-+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
id            | 49644016 --auto increment
detail        | 1651 misery-courtion 2272 ch470171978501
label         | <b>Misery-Courtion</b> 1651 (CH 4701 7197 8501)
origin        | parcel
geom_st_box2d | BOX(2574035.885 1189450.934,2574318.148 1189653.117)
num           | 1651
egris_egrid   | ch470171978501
x             | 189548.510472011 --centroid on real geometry
y             | 574185.263109655 --centroid on real geometry
st_asewkt     | SRID=2056;POLYGON((2574196.885 1189537.317,2574189.235 1189532.594,2574184.923 1189530.241,2574181.359 1189528.298,2574173.327 1189524.308,2574165.171 1189520.527,2574126.261 1189503.118,2574111.975 1189495.681,2574098.44 1189486.962,2574085.208 1189477.346,2574083.089 1189475.726,2574072.186 1189467.391,2574057.263 1189455.779,2574035.885 1189450.934,2574094.555 1189495.585,2574110.918 1189505.574,2574136.648 1189516.564,2574141.404 1189518.488,2574146.638 1189520.803,2574156.001 1189525.453,2574177.326 1189535.308,2574192.514 1189544.292,2574206.504 1189555.225,2574219.892 1189567.878,2574226.685 1189577.231,2574270.633 1189623.363,2574271.594 1189622.114,2574287.992 1189638.662,2574291.67 1189642.353,2574304.456 1189653.117,2574318.148 1189640.523,2574309.924 1189633.878,2574304.542 1189634.902,2574298.617 1189634.458,2574293.095 1189632.37,2574288.184 1189629.078,2574265.655 1189606.453,2574252.974 1189592.542,2574231.062 1189569.546,2574232.003 1189568.81,2574221.048 1189557.305,2574214.945 1189551.41,2574208.225 1189545.625,2574202.707 1189541.365,2574196.885 1189537.317))

dritte_master=> select id, detail, label, origin, geom_st_box2d, num, egris_egrid, x, y, st_asewkt(the_geom) FROM kantone.parzellen_sphinx  limit 1;
-[ RECORD 1 ]-+---------------------------------------------------------------------------------------------------------------------------------------------
id            | 93676 --objectid from zip file
detail        | 1651 misery-courtion 2272 ch470171978501
label         | <b>Misery-Courtion</b> 1651 (CH 4701 7197 8501)
origin        | parcel
geom_st_box2d | BOX(2574035.885 1189450.934,2574318.148 1189653.117)
num           | 1651
egris_egrid   | ch470171978501
x             | 189552.026 --centroid on bbox
y             | 574208.996 --centroid on bbox
st_asewkt     | SRID=2056;POLYGON((2574035.885 1189450.934,2574035.885 1189653.117,2574318.148 1189653.117,2574318.148 1189450.934,2574035.885 1189450.934))
```

@rebert @eraymann  there is no ``objectid`` or something similar in the os_realestate source table? You're importing all the attributes?

The geoshop parcel search source ``http://geodata01.admin.ch/cloud/gs_parzelle.zip`` has the following attributes:

```bash
"FILEID","OBJID","GEMEINDE","NUMMER","X","Y","EGRIS_EGRID","X1","Y1","X2","Y2","LASTUPDATE","NBIDENT","BFSNR"
60399,466993210,"Küssnacht (SZ)","4112",2677662.209,1216794.783,"CH939177874569",2677598.107,1216773.877,2677678.588,1216835.22,20140825,"SZ0200001331",1331
```