### PR TITLE
show more results if uuid is not matching between swissnames and dkm …

### DIFF
--- a/conf/search.conf.part
+++ b/conf/search.conf.part
@@ -196,7 +196,7 @@ source src_swissnames3d : src_swisssearch
         1 as num, \
         b.zoomlevel as zoomlevel \
     FROM swissnames_search s \
-    inner join tlm.dkm_search b on s.name = b.name and s.objektklasse = 'TLM_GEBAEUDE' and s.feature_id <> b.feature_id \
+    inner join tlm.dkm_search b on s.name = b.name and s.feature_id <> b.feature_id \
     ) s
 }
 


### PR DESCRIPTION
@davidoesch 
this change in the query will show more results of the dkm/swissnames combination if the uuid is not matching
p.e. gorihorn
[testlink](https://mf-geoadmin3.dev.bgdi.ch/)