### PR TITLE
IVS must use views (with restrictions) for the search

### DIFF
--- a/conf/uvek.conf.part
+++ b/conf/uvek.conf.part
@@ -97,7 +97,25 @@ source src_ch_astra_ivs_nat : def_searchable_features
             , box2d(st_transform(the_geom, 21781)) as geom_st_box2d \
             , box2d(st_transform(the_geom, 2056)) as geom_st_box2d_lv95 \
             , nat_id::text as feature_id \
-        from astra.ivs_nat
+        from astra.ivs_nat_tt
+}
+
+source src_ch_astra_ivs_nat_verlaeufe : def_searchable_features
+{
+    sql_db = uvek_dev
+    sql_query = \
+        SELECT nat_id::bigint as id \
+            , ivs_nummer as label \
+            , 'feature' as origin \
+            , remove_accents(ivs_slaname)||' '||remove_accents(ivs_nummer)||' '||remove_accents(ivs_signatur) as detail \
+            , 'ch.astra.ivs-nat-verlaeufe' as layer \
+            , quadindex(the_geom) as geom_quadindex \
+            , st_y(st_transform(st_ClosestPoint(the_geom,st_centroid(the_geom)),4326)) as lat \
+            , st_x(st_transform(st_ClosestPoint(the_geom,st_centroid(the_geom)),4326)) as lon \
+            , box2d(st_transform(the_geom, 21781)) as geom_st_box2d \
+            , box2d(st_transform(the_geom, 2056)) as geom_st_box2d_lv95 \
+            , nat_id::text as feature_id \
+        from astra.ivs_nat_verlaeufe_tt
 }
 
 source src_ch_astra_ivs_reg_loc : def_searchable_features
@@ -1502,6 +1520,7 @@ index ch_astra_ivs_nat
 
 index ch_astra_ivs_nat_verlaeufe : ch_astra_ivs_nat
 {
+    source = src_ch_astra_ivs_nat_verlaeufe
     path = /var/lib/sphinxsearch/data/index/ch_astra_ivs_nat_verlaeufe
 }
 


### PR DESCRIPTION
Layer IVS nat  and Ivs nat Verlaeufe has her proper table (it's a view of table ivs_nat with restriction on ivs_signature attribute).
Tooltip was already setting for using the view. Sphinx is now set too.