### PR TITLE
index multiple results with same feature_id (uuid) but different detail

### DIFF
--- a/conf/search.conf.part
+++ b/conf/search.conf.part
@@ -156,7 +156,7 @@ source src_swissnames3d : src_swisssearch
         ) sub \
         WHERE  objektart not like 'Haltestelle%' \
     ) \
-    select distinct on (feature_id) row_number() OVER(ORDER BY 1 asc) as id , * FROM \
+    select distinct on (feature_id, detail) row_number() OVER(ORDER BY 1 asc) as id , * FROM \
         ( \
     SELECT \
         coalesce(b.feature_id,s.feature_id) as feature_id, \


### PR DESCRIPTION
this will fix the lack of translated river and lake names in the swissearch index
related to https://github.com/geoadmin/service-sphinxsearch/issues/405

regression has been introduced with this https://github.com/geoadmin/mf-geoadmin3/issues/3941

[Testlink](https://mf-chsdi3.dev.bgdi.ch/shorten/8601c35bbc)
search for:
```
Silsersee
Langensee
Vierwaldstättersee
Genfersee
```