### PR TITLE
build sphinx indexes from master instance

### DIFF
--- a/conf/db.conf.in
+++ b/conf/db.conf.in
@@ -3,7 +3,7 @@
 source def_pqsql
 {
     type = pgsql
-    sql_host = pg-sandbox.bgdi.ch
+    sql_host = pg-0.dev.bgdi.ch
     sql_user = $PGUSER
     sql_pass = $PGPASS
     sql_port = 5432


### PR DESCRIPTION
since we we wont wait for any replication lags anymore on rds, we will build the sphinx index with the master database.