### PR TITLE
Fixing Codebuild docker push

### DIFF
--- a/buildspec.yml
+++ b/buildspec.yml
@@ -1,6 +1,7 @@
 version: 0.2
 
 env:
+  shell: bash
   variables:
     IMAGE_BASE_NAME: "service-search-sphinx"
     REGISTRY: "974517877189.dkr.ecr.eu-central-1.amazonaws.com"


### PR DESCRIPTION
By default the commands in buildspec are executed in `sh` we need to
specify the `shell: bash` tag to use bash. Bash allow us to use `[[` if
syntax.