### PR TITLE
rsync will only sync files with valid sphinx config prefix

### DIFF
--- a/dev.env
+++ b/dev.env
@@ -1,3 +1,4 @@
+# shellcheck disable=2034
 SPHINX_PORT=9312
 SPHINX_EFS=/var/local/efs-dev/geodata/service-sphinxsearch/dev/index/
 PGPASS=www-data

--- a/int.env
+++ b/int.env
@@ -1,3 +1,4 @@
+# shellcheck disable=2034
 SPHINX_PORT=9312
 SPHINX_EFS=/var/local/efs-dev/geodata/service-sphinxsearch/int/index/
 PGPASS=www-data

--- a/prod.env
+++ b/prod.env
@@ -1,5 +1,6 @@
+# shellcheck disable=2034
 SPHINX_PORT=9312
-SPHINX_EFS=/var/local/efs-dev/geodata/service-sphinxsearch/prod/index/
+SPHINX_EFS=/var/local/efs-prod/geodata/service-sphinxsearch/prod/index/
 PGPASS=www-data
 PGUSER=www-data
 PGHOST=master.chtopodb.bgdi.ch


### PR DESCRIPTION
the list of valid prefixes will be extracted from sphinx config and has
rsync include-from format:
index_a.*
index_b.*