### PR TITLE
BGDIINF_SB-2216: tweaks and optimizations

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -71,6 +71,8 @@ ifeq ($(DB_ACCESS),false)
 $(warning ${RED}we need a valid postgres connection for this correct use of makefile! connection to '$(PGHOST)' was not successful${RESET})
 endif
 
+PPID := $(shell echo $$PPID)
+
 # Maintenance / Index Commands
 # EFS Index will be mounted as bind mount
 export DOCKER_EXEC :=  docker run \
@@ -78,7 +80,7 @@ export DOCKER_EXEC :=  docker run \
 				-t \
 				-v $(SPHINX_EFS):/var/lib/sphinxsearch/data/index/ \
 				--env-file $(ENV_FILE) \
-				--name $(DOCKER_LOCAL_TAG)_maintenance \
+				--name $(DOCKER_LOCAL_TAG)_maintenance_$(PPID)\
 				$(DOCKER_IMG_LOCAL_TAG)
 
 export DOCKER_EXEC_LOCAL :=  docker run \
@@ -86,7 +88,7 @@ export DOCKER_EXEC_LOCAL :=  docker run \
 				-t \
 				-v $(CURRENT_DIR)/conf/:/var/lib/sphinxsearch/data/index/ \
 				--env-file $(ENV_FILE) \
-				--name $(DOCKER_LOCAL_TAG)_maintenance \
+				--name $(DOCKER_LOCAL_TAG)_maintenance_$(PPID) \
 				$(DOCKER_IMG_LOCAL_TAG)
 
 # AWS variables

--- a/scripts/pg2sphinx.sh
+++ b/scripts/pg2sphinx.sh
@@ -1,41 +1,6 @@
 #!/bin/bash
 set -euo pipefail
 
-LOCK_TAG=${DOCKER_INDEX_VOLUME}_maintenance_lock
-
-lock() {
-    # check if a maintenance job is running already already
-    # only one maintenance job / container is allowed to run to avoid disk sphinx config conflicts (*.new.* files, *.tmp.* files)
-    # wait loop for one hour
-    counter=0
-    max_counter=60 # max loops
-    nap_time=60 # loop time in seconds
-    while docker ps -a --format '{{.Names}}' | grep --silent "${LOCK_TAG}" -w; do
-        ((counter+=1))
-        if (( counter > max_counter )); then
-            >&2 echo "maintenance operations are locked"
-            exit 1
-        fi
-        echo "sphinx maintenance job is already running, loop ${counter}/${max_counter} every ${nap_time} seconds ..."
-        sleep ${nap_time}
-    done
-
-    docker run \
-        --rm \
-        -d \
-        -t \
-        -v "${SPHINX_EFS}":/var/lib/sphinxsearch/data/index/ \
-        --name "${LOCK_TAG}" \
-        "${DOCKER_IMG_LOCAL_TAG}" /bin/bash
-}
-
-unlock() {
-    docker stop "${LOCK_TAG}"
-}
-
-trap "unlock" exit
-lock
-
 if [ -n "${DB:-}" ]; then
     # call pg2sphinx trigger with DATABASE pattern
     ${DOCKER_EXEC} python3 pg2sphinx_trigger.py -s /etc/sphinxsearch/sphinx.conf -c update -d "${DB}"


### PR DESCRIPTION
for index maintenance triggered by database and table deploys
* remove locking
  since the sphinx index creation is writing into a filesystem it is not
  necessary to have a locking mechanism.
  the triggering database deploy itself is already locked, multiple
  processes writing into same database are not allowed

* multiple maintenance container/jobs can run at the same time, the
  container naming has to be extended with a random part (ppid)


the database deploy trigger will be changed here: https://github.com/geoadmin/deploy/pull/53