### PR TITLE
BGDIINF_SB-2216: pg2spshinx endpoint adaption for table deploy (automata and manual)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -75,9 +75,11 @@ PPID := $(shell echo $$PPID)
 
 # Maintenance / Index Commands
 # EFS Index will be mounted as bind mount
+# DOCKER_EXEC will always check if a newer image exists on ecr -> develop.latest support
 export DOCKER_EXEC :=  docker run \
 				--rm \
 				-t \
+				--pull=always \
 				-v $(SPHINX_EFS):/var/lib/sphinxsearch/data/index/ \
 				--env-file $(ENV_FILE) \
 				--name $(DOCKER_LOCAL_TAG)_maintenance_$(PPID)\
@@ -209,14 +211,14 @@ shellcheck:
 
 
 .PHONY: pg2sphinx
-pg2sphinx: load_env $(SPHINX_EFS) dockerbuild
+pg2sphinx: load_env $(SPHINX_EFS)
 ifndef INDEX
 ifndef DB
 	@echo "you have to set INDEX or DB variable for this target"
 	false
 endif
 endif
-	DOCKER_INDEX_VOLUME=$(DOCKER_INDEX_VOLUME) ./scripts/pg2sphinx.sh
+	./scripts/pg2sphinx.sh
 
 
 .PHONY: check-config-local

--- a/scripts/pg2sphinx.sh
+++ b/scripts/pg2sphinx.sh
@@ -1,6 +1,15 @@
 #!/bin/bash
 set -euo pipefail
 
+docker_is_logged_in() {
+    jq -e --arg url "${DOCKER_REGISTRY}" '.auths | has($url)' ~/.docker/config.json > /dev/null
+}
+
+# check if we are already logged in
+if ! docker_is_logged_in; then
+    make dockerlogin
+fi
+
 if [ -n "${DB:-}" ]; then
     # call pg2sphinx trigger with DATABASE pattern
     ${DOCKER_EXEC} python3 pg2sphinx_trigger.py -s /etc/sphinxsearch/sphinx.conf -c update -d "${DB}"


### PR DESCRIPTION
the pg2pshinx endpoint, triggered by database/table deploy script will:

* not start and use local builds anymore
* only use ecr images (built by codebuild) and always check for newer images on ecr.
* the current image tag for dev/int/prod tag is detected by the database deploy script https://github.com/geoadmin/deploy/pull/53

we have to assure to always use the latest image, p.e  stable image names like develop-docker.latest or develop.latest, etc.