### PR TITLE
BGDIINF_SB-2216: improve the validation of the ecr token

### DIFF
--- a/scripts/pg2sphinx.sh
+++ b/scripts/pg2sphinx.sh
@@ -2,7 +2,10 @@
 set -euo pipefail
 
 docker_is_logged_in() {
-    jq -e --arg url "${DOCKER_REGISTRY}" '.auths | has($url)' ~/.docker/config.json > /dev/null
+    # this will check if the ecr token is still valid
+    # the token expires after 12 hours so the credential info in
+    # ~/.docker/config.json might be misleading
+    ${DOCKER_EXEC} pwd &> /dev/null
 }
 
 # check if we are already logged in


### PR DESCRIPTION
the content of ~/.docker/config.json can be misleading because the token
is only valid for 12 hours.

after 12 hours the content of ~/.docker/config.json still contains the
credentials but a docker pull fails with this error:

docker: Error response from daemon: pull access denied
Your authorization token has expired. Reauthenticate and try again.