### PR TITLE
BGDIINF_SB-2530: service sphinxsearch liveness probe

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,7 +39,7 @@ RUN groupadd -r geodata -g 2500 && \
 FROM sphinxsearch_geodata
 
 # copy sphinxsearch config and maintenance code
-COPY --chown=geodata:geodata scripts/docker-* scripts/index-sync-rotate.sh scripts/pg2sphinx_trigger.py /
+COPY --chown=geodata:geodata scripts/docker-* scripts/index-sync-rotate.sh scripts/pg2sphinx_trigger.py scripts/checker.sh /
 COPY --chown=geodata:geodata conf /conf/
 
 # default CMD

--- a/scripts/checker.sh
+++ b/scripts/checker.sh
@@ -13,6 +13,7 @@ check_exit_code() {
     if [ ${exit_code} -ne 0 ]; then
         # Clear the readiness file
         echo "ERROR: Liveness probe failed with code ${exit_code}" # | tee "${checker_file}"
+        exit_code=1
     else
         # TODO: implement robust readiness check
         #./checker_ready.sh

--- a/scripts/checker.sh
+++ b/scripts/checker.sh
@@ -3,29 +3,5 @@ set -e
 set -u
 set -o pipefail
 
-
-check_exit_code() {
-    exit_code=$?
-    # full path to output file
-    #local checker_file="/var/lib/container_probes/checker_ready.txt"
-
-    # analyze exit code with trapped function
-    if [ ${exit_code} -ne 0 ]; then
-        # Clear the readiness file
-        echo "ERROR: Liveness probe failed with code ${exit_code}" # | tee "${checker_file}"
-        exit_code=1
-    else
-        # TODO: implement robust readiness check
-        #./checker_ready.sh
-        echo "READY" # | tee ${checker_file}
-    fi
-    exit ${exit_code}
-}
-
-# Capture Exit Code with trapped pseudo signal EXIT
-# When the script is completed or exits for any reason, the
-# commands in the check_exit_code function will be executed.
-trap check_exit_code EXIT
-
-# Do the lifeness check
-searchd --status 1> /dev/null
+# Do the lifeness check exit status 0 -> success | 1 -> fail
+searchd --status 1> /dev/null && exit 0 || exit 1

--- a/scripts/checker.sh
+++ b/scripts/checker.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+set -e
+set -u
+set -o pipefail
+
+
+check_exit_code() {
+    exit_code=$?
+    # full path to output file
+    local checker_file="/var/lib/container_probes/checker_ready.txt"
+
+    # analyze exit code with trapped function
+    if [ ${exit_code} -ne 0 ]; then
+        # Clear the readiness file
+        echo "ERROR: Liveness probe failed with code ${exit_code}" | tee "${checker_file}"
+    else
+        # TODO: implement robust readiness check
+        #./checker_ready.sh
+        echo "READY" | tee ${checker_file}
+    fi
+    exit ${exit_code}
+}
+
+# Capture Exit Code with trapped pseudo signal EXIT
+# When the script is completed or exits for any reason, the
+# commands in the check_exit_code function will be executed.
+trap check_exit_code EXIT
+
+# Do the lifeness check
+searchd --status 1> /dev/null

--- a/scripts/checker.sh
+++ b/scripts/checker.sh
@@ -7,16 +7,16 @@ set -o pipefail
 check_exit_code() {
     exit_code=$?
     # full path to output file
-    local checker_file="/var/lib/container_probes/checker_ready.txt"
+    #local checker_file="/var/lib/container_probes/checker_ready.txt"
 
     # analyze exit code with trapped function
     if [ ${exit_code} -ne 0 ]; then
         # Clear the readiness file
-        echo "ERROR: Liveness probe failed with code ${exit_code}" | tee "${checker_file}"
+        echo "ERROR: Liveness probe failed with code ${exit_code}" # | tee "${checker_file}"
     else
         # TODO: implement robust readiness check
         #./checker_ready.sh
-        echo "READY" | tee ${checker_file}
+        echo "READY" # | tee ${checker_file}
     fi
     exit ${exit_code}
 }


### PR DESCRIPTION
this is a first draft of a container liveness probe (checker.sh) for service-sphinxsearch which can be used as healtcheck with docker and docker-compose.

The check assumes that `searchd --status` exit code represents the liveness of the search container. once the searchd daemon is running, the container is supposed to be alive.
