### PR TITLE
fix table scan behaviour

### DIFF
--- a/scripts/pg2sphinx_trigger.py
+++ b/scripts/pg2sphinx_trigger.py
@@ -37,7 +37,7 @@ def pg_get_tables(sql_query, sql_db):
                 t.append(sql_db + '.' + table_i)
         t = list(set(t))  # get rid of duplicate entries in the list and sorting
         return ','.join(sorted(t))
-    except psycopg2.OperationalError as err:
+    except (psycopg2.ProgrammingError, psycopg2.OperationalError) as err:
         sys.stderr.write(
             f"ERROR: wrong query detected in database: {sql_query}"\
             f"\nquery:\n{sql_query}\nerror:\n{err}\n"


### PR DESCRIPTION
during a table deploy/scan, all the queries in the sphinx config of the current database are being executed with explain analzye. The result of this analyze  is used to detect indexes that have to be updated, indexes that rely on the table that has been deployed.

with this change the pg2sphinx trigger will continue its scan if one of. the sphinx queries is invalid. this can happen during deploy days when new configs/images are already activated but the database has not yet been deployed. until now this scenario has not been catched by the except block because it is a `ProgrammingError`.