### PR TITLE
extend the liveness probe with a swisssearch request

### DIFF
--- a/scripts/checker.sh
+++ b/scripts/checker.sh
@@ -11,10 +11,18 @@ clean_probe_files() {
     rm -f "${READY_FILE}" || :
 }
 
+swisssearch_status() {
+        mysql -P 9306 -h 0 -e "SELECT * FROM swisssearch where match('landstrasse 78');"
+}
+
+searchd_status() {
+        searchd --status
+}
+
 # source this stuff until here
 [ "$0" = "${BASH_SOURCE[*]}" ] || return 0
 
-if searchd --status 1> /dev/null; then
+if searchd_status 1> /dev/null && swisssearch_status 1> /dev/null; then
     echo "READY" > "${READY_FILE}"
     exit 0
 else


### PR DESCRIPTION
searchd status can be ok before the swisssearch requests are working 504 errors are responded at that momennt. it takes a moment before the swisssearch requests are served correctly.

with this extension the container won't be tagged healthy before swisssearch requests are working