### PR TITLE
BGDIINF_SB-2562: make the logs searchd.log and query.log visible

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,7 @@ RUN apt-get update && \
     default-mysql-client \
     gettext-base \
     gosu \
+    jq \
     procps \
     rsync \
     sphinxsearch && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,9 @@ RUN apt-get update && \
     gosu nobody true && \
     # set up cron for non root user
     chmod gu+rw /var/run && \
-    chmod gu+s /usr/sbin/cron
+    chmod gu+s /usr/sbin/cron &&\
+    mkfifo /tmp/stdout /tmp/stderr && \
+    chmod 0666 /tmp/stdout /tmp/stderr
 
     # set up geodata, file permissions, copy files and run container as geodata
 FROM sphinxsearch_base as sphinxsearch_geodata
@@ -25,9 +27,6 @@ RUN groupadd -r geodata -g 2500 && \
     # create mountpoint folders with geodata ownership
     install -o geodata -g geodata -d /var/lib/sphinxsearch/data/index/ && \
     install -o geodata -p geodata -d /var/lib/sphinxsearch/data/index_efs/ && \
-    # TODO: redirect logs to stdout # only working if container is running as root
-    # ln -sv /dev/stdout /var/log/sphinxsearch/query.log && \
-    # ln -sv /dev/stdout /var/log/sphinxsearch/searchd.log && \
     # change ownerships to geodata which will run the service or the maintenance scripts
     # and mount the efs folder
     chown -R geodata:geodata /var/run/sphinxsearch/ && \

--- a/scripts/docker-cmd.sh
+++ b/scripts/docker-cmd.sh
@@ -49,9 +49,14 @@ crontab < docker-crontab
 echo -e "${green}starting searchd service ...${NC}"
 
 # prepare the applogs for output on /proc/1/fd/1
-rm -rf /var/log/sphinxsearch/query.log /var/log/sphinxsearch/searchd.log
 tail --pid $$ -F /var/log/sphinxsearch/searchd.log &
 tail --pid $$ -F /var/log/sphinxsearch/query.log &
+
+# prepare the logs for the cronjobs
+# Have the main Docker process tail the files to produce stdout and stderr
+# for the main process that Docker will actually show in docker logs.
+tail -f /tmp/stdout &
+tail -f /tmp/stderr >&2 &
 
 # searchd will own pid 1
 exec /usr/bin/searchd  --nodetach "$@"

--- a/scripts/docker-cmd.sh
+++ b/scripts/docker-cmd.sh
@@ -47,4 +47,11 @@ crontab < docker-crontab
 # starting the searchd service
 # will load the sphinx indexes from EFS --sync--> Volume --> into memory
 echo -e "${green}starting searchd service ...${NC}"
-/usr/bin/searchd --nodetach "$@"
+
+# prepare the applogs for output on /proc/1/fd/1
+rm -rf /var/log/sphinxsearch/query.log /var/log/sphinxsearch/searchd.log
+tail --pid $$ -F /var/log/sphinxsearch/searchd.log &
+tail --pid $$ -F /var/log/sphinxsearch/query.log &
+
+# searchd will own pid 1
+exec /usr/bin/searchd  --nodetach "$@"

--- a/scripts/docker-crontab
+++ b/scripts/docker-crontab
@@ -9,4 +9,8 @@ SHELL="/bin/bash"
 USER="geodata"
 
 */5 * * * * bash /index-sync-rotate.sh
+
+# truncate sphinx logs
+0 0 * * * : > /var/log/sphinxsearch/searchd.log
+0 0 * * * : > /var/log/sphinxsearch/query.log
 # it is important to add a new-line

--- a/scripts/docker-crontab
+++ b/scripts/docker-crontab
@@ -8,7 +8,7 @@
 SHELL="/bin/bash"
 USER="geodata"
 
-*/5 * * * * bash /index-sync-rotate.sh
+*/5 * * * * bash /index-sync-rotate.sh 1>/tmp/stdout 2>/tmp/stderr
 
 # truncate sphinx logs
 0 0 * * * : > /var/log/sphinxsearch/searchd.log


### PR DESCRIPTION
make the logs searchd.log and query.log visible in the stdout of the docker main process pid=1 `/proc/1/fd/1` . with this modification these logs will be visible in docker logs.

truncate the searchd logs in the container each night