### PR TITLE
Fix address rotation issue

### DIFF
--- a/scripts/index-sync-rotate.sh
+++ b/scripts/index-sync-rotate.sh
@@ -144,7 +144,7 @@ for sphinx_index in ${SPHINX_INDEXES[@]}; do
         new_file_renamed=$(sed 's/\.sp\(\w\)$/.new.sp\1/' <<< "${new_file}")
         cp -fa "${SPHINX_EFS}${new_file}" "${SPHINX_VOLUME}${new_file_renamed}"
         tmp_array+=("${new_file_renamed}")
-    done <   <(find "${SPHINX_EFS}" -name "${sphinx_index}*" -print0)
+    done <   <(find "${SPHINX_EFS}" -name "${sphinx_index}.*" -print0)
 
     if ((${#tmp_array[@]})); then
         # remove blank strings from array

--- a/scripts/index-sync-rotate.sh
+++ b/scripts/index-sync-rotate.sh
@@ -138,6 +138,7 @@ for sphinx_index in ${SPHINX_INDEXES[@]}; do
     tmp_array=()
 
     while IFS= read -r -d '' new_file; do
+        echo "copy new file: $new_file" | json_logger INFO
         new_file=$(basename "${new_file}")
         # shellcheck disable=2001
         new_file_renamed=$(sed 's/\.sp\(\w\)$/.new.sp\1/' <<< "${new_file}")
@@ -158,11 +159,14 @@ for sphinx_index in ${SPHINX_INDEXES[@]}; do
             all_files_are_gone=false
             while ! ${all_files_are_gone}; do
                 all_files_are_gone=true
+                echo "about to rotate ${sphinx_index}, waiting for ${new_files_merged[*]} to disappear" | json_logger INFO
                 for new_file in ${new_files_merged[@]}; do
                     # skip empty elements
                     [[ -z ${new_file} ]] && continue
                     [ -f "${SPHINX_VOLUME}${new_file}" ] && all_files_are_gone=false
                 done
+                # shellcheck disable=SC2046
+                ${all_files_are_gone} || echo "still exist:" $( cd "${SPHINX_VOLUME}"; ls "${new_files_merged[@]}" 2> /dev/null ) | json_logger INFO
                 sleep 5
             done
         fi


### PR DESCRIPTION
without the dot in the -name parameter the address_metaphone* indexes
have been synced and rotated together with the address index.
```bash
sphinx_index=address

# before the fix
$ ls ${sphinx_index}*
address.spa  address.sph  address.spl  address.sps            address_metaphone.spe  address_metaphone.spk  address_metaphone.spp   address_metaphone.tmp1
address.spd  address.spi  address.spm  address_metaphone.spa  address_metaphone.sph  address_metaphone.spl  address_metaphone.sps   address_metaphone.tmp7
address.spe  address.spk  address.spp  address_metaphone.spd  address_metaphone.spi  address_metaphone.spm  address_metaphone.tmp0  address_metaphone.tmps

# after the fix
$ ls ${sphinx_index}.*
address.spa  address.spd  address.spe  address.sph  address.spi  address.spk  address.spl  address.spm  address.spp  address.sps
```
since this index will be created right after the address index, it has
been synced in an instable state into the docker volume. 

this has led to problems with the index rotation -> SegFault crash of searchd