### PR TITLE
improvements in the stability of the index rotation script

### DIFF
--- a/scripts/index-sync-rotate.sh
+++ b/scripts/index-sync-rotate.sh
@@ -59,7 +59,7 @@ SPHINX_INDEX_READY=('spd' 'spe' 'sph' 'spi' 'spp' 'sps')
 SPHINX_INDEXES=$(grep -E "^[^#]+ path" "${SPHINXCONFIG}" | awk -F"=" '{print $2}' | sed -n -e 's|^.*/||p')
 
 # global locking, no parallel syncing from efs into docker volumes
-LOCKFILE="${SPHINX_EFS}$(basename "$0")"
+LOCKFILE="/tmp/$(basename "$0")"
 LOCKFD=99
 
 # PRIVATE

--- a/scripts/index-sync-rotate.sh
+++ b/scripts/index-sync-rotate.sh
@@ -58,7 +58,6 @@ SPHINX_FILE_EXTENSIONS=('spa' 'spd' 'spe' 'sph' 'spi' 'spk' 'spm' 'spp' 'sps')
 SPHINX_INDEX_READY=('spd' 'spe' 'sph' 'spi' 'spp' 'sps')
 SPHINX_INDEXES=$(grep -E "^[^#]+ path" "${SPHINXCONFIG}" | awk -F"=" '{print $2}' | sed -n -e 's|^.*/||p')
 
-# global locking, no parallel syncing from efs into docker volumes
 LOCKFILE="/tmp/$(basename "$0")"
 LOCKFD=99
 

--- a/scripts/index-sync-rotate.sh
+++ b/scripts/index-sync-rotate.sh
@@ -136,7 +136,10 @@ for sphinx_index in ${SPHINX_INDEXES[@]}; do
     # sync EFS to VOLUME
     echo "start sync and rename files in target folder: ${sphinx_index} ..." | json_logger INFO
     tmp_array=()
-
+    # find and copy only files with valid file extension
+    # find will be expanded to:
+    # find /var/local/geodata/service-sphinxsearch/prod/index/ -regex "^.*/layers_de.\(spa\|spd\|spe\|sph\|spi\|spk\|spm\|spp\)$^
+    find_extensions="${SPHINX_FILE_EXTENSIONS[*]}"
     while IFS= read -r -d '' new_file; do
         echo "copy new file: $new_file" | json_logger INFO
         new_file=$(basename "${new_file}")
@@ -144,7 +147,7 @@ for sphinx_index in ${SPHINX_INDEXES[@]}; do
         new_file_renamed=$(sed 's/\.sp\(\w\)$/.new.sp\1/' <<< "${new_file}")
         cp -fa "${SPHINX_EFS}${new_file}" "${SPHINX_VOLUME}${new_file_renamed}"
         tmp_array+=("${new_file_renamed}")
-    done <   <(find "${SPHINX_EFS}" -name "${sphinx_index}.*" -print0)
+    done <   <(find "${SPHINX_EFS}" -regex "^.*/${sphinx_index}.\(${find_extensions// /\\|}\)$" -print0)
 
     if ((${#tmp_array[@]})); then
         # remove blank strings from array


### PR DESCRIPTION
- fixes https://github.com/geoadmin/service-sphinxsearch/issues/539

- fixes permanent lock when index update is happening between efs index ready check and copy efs->docker volume (https://jira.swisstopo.ch/browse/BGDIDIC-1457)
```
WARNING: rotating index 'layers_fr': prealloc: failed to load /var/lib/sphinxsearch/data/index/layers_fr.new.spi: bad size 0 (at least 1 bytes expected); using old index
```
- removes global lock file, since the rotation of the indexes is now working stable we can sync them into the vhosts at the same time.