### PR TITLE
BGDIDIC-2643: remove remove_accents

### DIFF
--- a/conf/bafu.conf.part
+++ b/conf/bafu.conf.part
@@ -1234,7 +1234,7 @@ source src_ch_bafu_fauna_wildtierpassagen : def_searchable_features
         SELECT bgdi_id as id \
             , name as label \
             , 'feature' as origin \
-            , remove_accents(name) as detail \
+            , name as detail \
             , 'ch.bafu.fauna-wildtierpassagen' as layer \
             , quadindex(the_geom) as geom_quadindex \
             , st_y(st_transform(st_centroid(the_geom),4326)) as lat \


### PR DESCRIPTION
Could remove_accents causes a problem without concat_ws? The search query seems to return no feature when I test it (I redeployed the table to update the indexes): https://sys-s.dev.bgdi.ch/a199e1eeaf
The sql query works well when I test it alone.