### PR TITLE
BGDIDIC-124: update table and field names

### DIFF
--- a/conf/uvek.conf.part
+++ b/conf/uvek.conf.part
@@ -290,7 +290,7 @@ source src_ch_bakom_notruf_112_festnetz : def_searchable_features
         SELECT bfs_nummer::bigint as id \
             ,  name as label \
             , 'feature' as origin \
-            , remove_accents(concat_ws(' ', festnetz_112, fn_addresse_112)) as detail \
+            , remove_accents(concat_ws(' ', phone_number, address)) as detail \
             , 'ch.bakom.notruf-112_festnetz' as layer \
             , quadindex(the_geom) as geom_quadindex \
             , st_y(st_transform(st_ClosestPoint(the_geom,st_centroid(the_geom)),4326)) as lat \
@@ -298,7 +298,7 @@ source src_ch_bakom_notruf_112_festnetz : def_searchable_features
             , box2d(st_transform(the_geom, 21781)) as geom_st_box2d \
             , box2d(st_transform(the_geom, 2056)) as geom_st_box2d_lv95 \
             , bfs_nummer::text as feature_id \
-        from bakom.notruf
+        from bakom.fn_112_tooltip
 }
 
 
@@ -309,7 +309,7 @@ source src_ch_bakom_notruf_117_festnetz : def_searchable_features
         SELECT bfs_nummer::bigint as id \
             ,  name as label \
             , 'feature' as origin \
-            , remove_accents(concat_ws(' ', festnetz_117, fn_addresse_117)) as detail \
+            , remove_accents(concat_ws(' ', phone_number, address)) as detail \
             , 'ch.bakom.notruf-117_festnetz' as layer \
             , quadindex(the_geom) as geom_quadindex \
             , st_y(st_transform(st_ClosestPoint(the_geom,st_centroid(the_geom)),4326)) as lat \
@@ -317,7 +317,7 @@ source src_ch_bakom_notruf_117_festnetz : def_searchable_features
             , box2d(st_transform(the_geom, 21781)) as geom_st_box2d \
             , box2d(st_transform(the_geom, 2056)) as geom_st_box2d_lv95 \
             , bfs_nummer::text as feature_id \
-        from bakom.notruf
+        from bakom.fn_117_tooltip
 }
 
 
@@ -328,7 +328,7 @@ source src_ch_bakom_notruf_118_festnetz : def_searchable_features
         SELECT bfs_nummer::bigint as id \
             ,  name as label \
             , 'feature' as origin \
-            , remove_accents(concat_ws(' ', festnetz_118, fn_addresse_118)) as detail \
+            , remove_accents(concat_ws(' ', phone_number, address)) as detail \
             , 'ch.bakom.notruf-118_festnetz' as layer \
             , quadindex(the_geom) as geom_quadindex \
             , st_y(st_transform(st_ClosestPoint(the_geom,st_centroid(the_geom)),4326)) as lat \
@@ -336,7 +336,7 @@ source src_ch_bakom_notruf_118_festnetz : def_searchable_features
             , box2d(st_transform(the_geom, 21781)) as geom_st_box2d \
             , box2d(st_transform(the_geom, 2056)) as geom_st_box2d_lv95 \
             , bfs_nummer::text as feature_id \
-        from bakom.notruf
+        from bakom.fn_118_tooltip
 }
 
 
@@ -347,7 +347,7 @@ source src_ch_bakom_notruf_143_festnetz : def_searchable_features
         SELECT bfs_nummer::bigint as id \
             ,  name as label \
             , 'feature' as origin \
-            , remove_accents(concat_ws(' ', festnetz_143, fn_addresse_143)) as detail \
+            , remove_accents(concat_ws(' ', phone_number, address)) as detail \
             , 'ch.bakom.notruf-143_festnetz' as layer \
             , quadindex(the_geom) as geom_quadindex \
             , st_y(st_transform(st_ClosestPoint(the_geom,st_centroid(the_geom)),4326)) as lat \
@@ -355,7 +355,7 @@ source src_ch_bakom_notruf_143_festnetz : def_searchable_features
             , box2d(st_transform(the_geom, 21781)) as geom_st_box2d \
             , box2d(st_transform(the_geom, 2056)) as geom_st_box2d_lv95 \
             , bfs_nummer::text as feature_id \
-        from bakom.notruf
+        from bakom.fn_143_tooltip
 }
 
 
@@ -366,7 +366,7 @@ source src_ch_bakom_notruf_144_festnetz : def_searchable_features
         SELECT bfs_nummer::bigint as id \
             ,  name as label \
             , 'feature' as origin \
-            , remove_accents(concat_ws(' ', festnetz_144, fn_addresse_144)) as detail \
+            , remove_accents(concat_ws(' ', phone_number, address)) as detail \
             , 'ch.bakom.notruf-144_festnetz' as layer \
             , quadindex(the_geom) as geom_quadindex \
             , st_y(st_transform(st_ClosestPoint(the_geom,st_centroid(the_geom)),4326)) as lat \
@@ -374,7 +374,7 @@ source src_ch_bakom_notruf_144_festnetz : def_searchable_features
             , box2d(st_transform(the_geom, 21781)) as geom_st_box2d \
             , box2d(st_transform(the_geom, 2056)) as geom_st_box2d_lv95 \
             , bfs_nummer::text as feature_id \
-        from bakom.notruf
+        from bakom.fn_144_tooltip
 }
 
 
@@ -385,7 +385,7 @@ source src_ch_bakom_notruf_145_festnetz : def_searchable_features
         SELECT bfs_nummer::bigint as id \
             ,  name as label \
             , 'feature' as origin \
-            , remove_accents(concat_ws(' ', festnetz_145, fn_addresse_145)) as detail \
+            , remove_accents(concat_ws(' ', phone_number, address)) as detail \
             , 'ch.bakom.notruf-145_festnetz' as layer \
             , quadindex(the_geom) as geom_quadindex \
             , st_y(st_transform(st_ClosestPoint(the_geom,st_centroid(the_geom)),4326)) as lat \
@@ -393,7 +393,7 @@ source src_ch_bakom_notruf_145_festnetz : def_searchable_features
             , box2d(st_transform(the_geom, 21781)) as geom_st_box2d \
             , box2d(st_transform(the_geom, 2056)) as geom_st_box2d_lv95 \
             , bfs_nummer::text as feature_id \
-        from bakom.notruf
+        from bakom.fn_145_tooltip
 }
 
 
@@ -404,7 +404,7 @@ source src_ch_bakom_notruf_147_festnetz : def_searchable_features
         SELECT bfs_nummer::bigint as id \
             ,  name as label \
             , 'feature' as origin \
-            , remove_accents(concat_ws(' ', festnetz_147, fn_addresse_147)) as detail \
+            , remove_accents(concat_ws(' ', phone_number, address)) as detail \
             , 'ch.bakom.notruf-147_festnetz' as layer \
             , quadindex(the_geom) as geom_quadindex \
             , st_y(st_transform(st_ClosestPoint(the_geom,st_centroid(the_geom)),4326)) as lat \
@@ -412,7 +412,7 @@ source src_ch_bakom_notruf_147_festnetz : def_searchable_features
             , box2d(st_transform(the_geom, 21781)) as geom_st_box2d \
             , box2d(st_transform(the_geom, 2056)) as geom_st_box2d_lv95 \
             , bfs_nummer::text as feature_id \
-        from bakom.notruf
+        from bakom.fn_147_tooltip
 }
 
 
@@ -423,7 +423,7 @@ source src_ch_bakom_notruf_112_satellit : def_searchable_features
         SELECT bfs_nummer::bigint as id \
             ,  name as label \
             , 'feature' as origin \
-            , remove_accents(concat_ws(' ', satellit_112, sa_addresse_112)) as detail \
+            , remove_accents(concat_ws(' ', phone_number, address)) as detail \
             , 'ch.bakom.notruf-112_satellit' as layer \
             , quadindex(the_geom) as geom_quadindex \
             , st_y(st_transform(st_ClosestPoint(the_geom,st_centroid(the_geom)),4326)) as lat \
@@ -431,7 +431,7 @@ source src_ch_bakom_notruf_112_satellit : def_searchable_features
             , box2d(st_transform(the_geom, 21781)) as geom_st_box2d \
             , box2d(st_transform(the_geom, 2056)) as geom_st_box2d_lv95 \
             , bfs_nummer::text as feature_id \
-        from bakom.notruf
+        from bakom.sa_112_tooltip
 }
 
 
@@ -442,7 +442,7 @@ source src_ch_bakom_notruf_112_mobilnetz : def_searchable_features
         SELECT bfs_nummer::bigint as id \
             ,  name as label \
             , 'feature' as origin \
-            , remove_accents(concat_ws(' ', mobile_112, mo_addresse_112)) as detail \
+            , remove_accents(concat_ws(' ', phone_number, address)) as detail \
             , 'ch.bakom.notruf-112_mobilnetz' as layer \
             , quadindex(the_geom) as geom_quadindex \
             , st_y(st_transform(st_ClosestPoint(the_geom,st_centroid(the_geom)),4326)) as lat \
@@ -450,7 +450,7 @@ source src_ch_bakom_notruf_112_mobilnetz : def_searchable_features
             , box2d(st_transform(the_geom, 21781)) as geom_st_box2d \
             , box2d(st_transform(the_geom, 2056)) as geom_st_box2d_lv95 \
             , bfs_nummer::text as feature_id \
-        from bakom.notruf
+        from bakom.mo_112_tooltip
 }
 
 
@@ -461,7 +461,7 @@ source src_ch_bakom_notruf_117_mobilnetz : def_searchable_features
         SELECT bfs_nummer::bigint as id \
             ,  name as label \
             , 'feature' as origin \
-            , remove_accents(concat_ws(' ', mobile_117, mo_addresse_117)) as detail \
+            , remove_accents(concat_ws(' ', phone_number, address)) as detail \
             , 'ch.bakom.notruf-117_mobilnetz' as layer \
             , quadindex(the_geom) as geom_quadindex \
             , st_y(st_transform(st_ClosestPoint(the_geom,st_centroid(the_geom)),4326)) as lat \
@@ -469,7 +469,7 @@ source src_ch_bakom_notruf_117_mobilnetz : def_searchable_features
             , box2d(st_transform(the_geom, 21781)) as geom_st_box2d \
             , box2d(st_transform(the_geom, 2056)) as geom_st_box2d_lv95 \
             , bfs_nummer::text as feature_id \
-        from bakom.notruf
+        from bakom.mo_117_tooltip
 }
 
 
@@ -480,7 +480,7 @@ source src_ch_bakom_notruf_118_mobilnetz : def_searchable_features
         SELECT bfs_nummer::bigint as id \
             ,  name as label \
             , 'feature' as origin \
-            , remove_accents(concat_ws(' ', mobile_118, mo_addresse_118)) as detail \
+            , remove_accents(concat_ws(' ', phone_number, address)) as detail \
             , 'ch.bakom.notruf-118_mobilnetz' as layer \
             , quadindex(the_geom) as geom_quadindex \
             , st_y(st_transform(st_ClosestPoint(the_geom,st_centroid(the_geom)),4326)) as lat \
@@ -488,7 +488,7 @@ source src_ch_bakom_notruf_118_mobilnetz : def_searchable_features
             , box2d(st_transform(the_geom, 21781)) as geom_st_box2d \
             , box2d(st_transform(the_geom, 2056)) as geom_st_box2d_lv95 \
             , bfs_nummer::text as feature_id \
-        from bakom.notruf
+        from bakom.mo_118_tooltip
 }
 
 
@@ -499,7 +499,7 @@ source src_ch_bakom_notruf_143_mobilnetz : def_searchable_features
         SELECT bfs_nummer::bigint as id \
             ,  name as label \
             , 'feature' as origin \
-            , remove_accents(concat_ws(' ', mobile_143, mo_addresse_143)) as detail \
+            , remove_accents(concat_ws(' ', phone_number, address)) as detail \
             , 'ch.bakom.notruf-143_mobilnetz' as layer \
             , quadindex(the_geom) as geom_quadindex \
             , st_y(st_transform(st_ClosestPoint(the_geom,st_centroid(the_geom)),4326)) as lat \
@@ -507,7 +507,7 @@ source src_ch_bakom_notruf_143_mobilnetz : def_searchable_features
             , box2d(st_transform(the_geom, 21781)) as geom_st_box2d \
             , box2d(st_transform(the_geom, 2056)) as geom_st_box2d_lv95 \
             , bfs_nummer::text as feature_id \
-        from bakom.notruf
+        from bakom.mo_143_tooltip
 }
 
 
@@ -518,7 +518,7 @@ source src_ch_bakom_notruf_144_mobilnetz : def_searchable_features
         SELECT bfs_nummer::bigint as id \
             ,  name as label \
             , 'feature' as origin \
-            , remove_accents(concat_ws(' ', mobile_144, mo_addresse_144)) as detail \
+            , remove_accents(concat_ws(' ', phone_number, address)) as detail \
             , 'ch.bakom.notruf-144_mobilnetz' as layer \
             , quadindex(the_geom) as geom_quadindex \
             , st_y(st_transform(st_ClosestPoint(the_geom,st_centroid(the_geom)),4326)) as lat \
@@ -526,7 +526,7 @@ source src_ch_bakom_notruf_144_mobilnetz : def_searchable_features
             , box2d(st_transform(the_geom, 21781)) as geom_st_box2d \
             , box2d(st_transform(the_geom, 2056)) as geom_st_box2d_lv95 \
             , bfs_nummer::text as feature_id \
-        from bakom.notruf
+        from bakom.mo_144_tooltip
 }
 
 
@@ -537,7 +537,7 @@ source src_ch_bakom_notruf_145_mobilnetz : def_searchable_features
         SELECT bfs_nummer::bigint as id \
             ,  name as label \
             , 'feature' as origin \
-            , remove_accents(concat_ws(' ', mobile_145, mo_addresse_145)) as detail \
+            , remove_accents(concat_ws(' ', phone_number, address)) as detail \
             , 'ch.bakom.notruf-145_mobilnetz' as layer \
             , quadindex(the_geom) as geom_quadindex \
             , st_y(st_transform(st_ClosestPoint(the_geom,st_centroid(the_geom)),4326)) as lat \
@@ -545,7 +545,7 @@ source src_ch_bakom_notruf_145_mobilnetz : def_searchable_features
             , box2d(st_transform(the_geom, 21781)) as geom_st_box2d \
             , box2d(st_transform(the_geom, 2056)) as geom_st_box2d_lv95 \
             , bfs_nummer::text as feature_id \
-        from bakom.notruf
+        from bakom.mo_145_tooltip
 }
 
 
@@ -556,7 +556,7 @@ source src_ch_bakom_notruf_147_mobilnetz : def_searchable_features
         SELECT bfs_nummer::bigint as id \
             ,  name as label \
             , 'feature' as origin \
-            , remove_accents(concat_ws(' ', mobile_147, mo_addresse_147)) as detail \
+            , remove_accents(concat_ws(' ', phone_number, address)) as detail \
             , 'ch.bakom.notruf-147_mobilnetz' as layer \
             , quadindex(the_geom) as geom_quadindex \
             , st_y(st_transform(st_ClosestPoint(the_geom,st_centroid(the_geom)),4326)) as lat \
@@ -564,7 +564,7 @@ source src_ch_bakom_notruf_147_mobilnetz : def_searchable_features
             , box2d(st_transform(the_geom, 21781)) as geom_st_box2d \
             , box2d(st_transform(the_geom, 2056)) as geom_st_box2d_lv95 \
             , bfs_nummer::text as feature_id \
-        from bakom.notruf
+        from bakom.mo_147_tooltip
 }
 
 


### PR DESCRIPTION
@ltclm For this one, bfs_nummer is unique inside a view but can be duplicated across the various views of the layer ch.swisstopo.geologie-tektonische_karte.

Is it sufficient the bfs_nummer to be unique inside a view? or do I need to concatenate another string/number to it to make it unique acroos all the views?