### PR TITLE
fix: prevent index deletion on config read failure

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -86,7 +86,7 @@ export DOCKER_EXEC :=  docker run \
 				--rm \
 				-t \
 				-v $(SPHINX_EFS):/var/lib/sphinxsearch/data/index/ \
-				--env-file $(ENV_FILE) \
+				--env-file $(CURRENT_DIR)/$(ENV_FILE) \
 				--name $(DOCKER_LOCAL_TAG)_maintenance_$(PPID)\
 				$(DOCKER_IMG_LOCAL_TAG)
 
@@ -94,7 +94,7 @@ export DOCKER_EXEC_LOCAL :=  docker run \
 				--rm \
 				-t \
 				-v $(CURRENT_DIR)/conf/:/var/lib/sphinxsearch/data/index/ \
-				--env-file $(ENV_FILE) \
+				--env-file $(CURRENT_DIR)/$(ENV_FILE) \
 				--name $(DOCKER_LOCAL_TAG)_maintenance_$(PPID) \
 				$(DOCKER_IMG_LOCAL_TAG)
 
@@ -286,7 +286,7 @@ dockerrun: dockerbuild sphinx_efs
 		-p $(SPHINX_PORT):$(SPHINX_PORT) \
 		-v $(SPHINX_EFS):/var/lib/sphinxsearch/data/index_efs/ \
 		-v ${DOCKER_INDEX_VOLUME}:/var/lib/sphinxsearch/data/index/ \
-		--env-file $(ENV_FILE) \
+		--env-file $(CURRENT_DIR)/$(ENV_FILE) \
 		--name $(DOCKER_LOCAL_TAG) \
 		$(DOCKER_IMG_LOCAL_TAG)
 
@@ -299,6 +299,6 @@ dockerrundebug: dockerbuild sphinx_efs
 		-p $(SPHINX_PORT):$(SPHINX_PORT) \
 		-v $(SPHINX_EFS):/var/lib/sphinxsearch/data/index_efs/ \
 		-v ${DOCKER_INDEX_VOLUME}:/var/lib/sphinxsearch/data/index/ \
-		--env-file $(ENV_FILE) \
+		--env-file $(CURRENT_DIR)/$(ENV_FILE) \
 		--name $(DOCKER_LOCAL_TAG) \
 		$(DOCKER_IMG_LOCAL_TAG)

--- a/scripts/pg2sphinx.sh
+++ b/scripts/pg2sphinx.sh
@@ -39,12 +39,26 @@ if [ -n "${INDEX:-}" ]; then
     ${DOCKER_EXEC} python3 pg2sphinx_trigger.py -s /etc/sphinxsearch/sphinx.conf -c update -i "${INDEX}" || { throw_error $?; }
 fi
 
-mapfile -t array_config < <(${DOCKER_EXEC} cat /etc/sphinxsearch/sphinx.conf | grep -E "^[^#]+ path"  | awk -F"=" '{print $2}' | sed -n 's|^.*/||p' | sed 's/\r$//')
+# Read config file to identify valid indexes
+# Safety: If this fails, we must NOT proceed with orphan deletion to avoid removing all indexes
+if ! mapfile -t array_config < <(${DOCKER_EXEC} cat /etc/sphinxsearch/sphinx.conf | grep -E "^[^#]+ path"  | awk -F"=" '{print $2}' | sed -n 's|^.*/||p' | sed 's/\r$//'); then
+    >&2 echo "ERROR: Failed to read sphinx config file. Skipping orphan cleanup to avoid data loss."
+    exit 0
+fi
+
+# Safety check: Ensure we actually got some indexes from the config
+if [[ ${#array_config[@]} -eq 0 ]]; then
+    >&2 echo "ERROR: No indexes found in sphinx config. Skipping orphan cleanup to avoid data loss."
+    exit 0
+fi
+
 mapfile -t array_file < <(find "${SPHINX_EFS}" -maxdepth 1 -name "*.spd" 2> /dev/null | sed 's|.spd$||g' | sed -n -e 's|^.*/||p' )
 mapfile -t array_orphaned < <(comm -13 --nocheck-order <(printf '%s\n' "${array_config[@]}" | LC_ALL=C sort) <(printf '%s\n' "${array_file[@]}" | LC_ALL=C sort))
 
-# remove orphaned indexes from EFS
 echo "looking for orphaned indexes in filesystem."
+echo "Config defines ${#array_config[@]} indexes, filesystem has ${#array_file[@]} indexes, ${#array_orphaned[@]} orphaned."
+
+# remove orphaned indexes from EFS
 for index in "${array_orphaned[@]}"; do
     # skip empty elements
     [[ -z ${index} ]] && continue


### PR DESCRIPTION
Add multiple safety checks to prevent data loss when docker commands fail:
1. Check docker command exit code before proceeding with cleanup
2. Verify array_config is not empty (prevents treating all indexes as orphaned)
3. Add informative logging showing index counts

Also fix relative path issue in Makefile that caused 'dev.env not found' error
by using absolute paths with CURRENT_DIR for all --env-file parameters.

Root cause: When db-deploy-sphinx folder was deleted and recreated, the missing
dev.env file caused docker commands to fail silently, resulting in empty array_config and all indexes being deleted as 'orphaned'.